### PR TITLE
Techdebt atualizar a pagina de documentacao do codex neodv 1517

### DIFF
--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -16,9 +16,9 @@ Pacote para interagir com o MLOps, uma ferramenta para deploy de modelos de Mach
 
 ### Como usar
 
-Leia a [documentação](https://datarisk-io.github.io/mlops-mlops_codex) para mais informações.
+Leia a [documentação](https://datarisk-io.github.io/mlops_codex) para mais informações.
 
-Disponibilizamos também alguns notebooks de [exemplo](https://github.com/datarisk-io/mlops-mlops_codex/tree/master/notebooks).
+Disponibilizamos também alguns notebooks de [exemplo](https://github.com/datarisk-io/mlops_codex/tree/master/notebooks).
 
 ### Para desenvolvedores
 

--- a/docs/source/base.rst
+++ b/docs/source/base.rst
@@ -5,7 +5,7 @@ Base module
 Module with the base classes used at MLOps.
 
 
-mlops\_codex.base.BaseMLOps
+BaseMLOps
 --------------------------------------------------
 
 .. autoclass:: mlops_codex.base.BaseMLOps
@@ -14,7 +14,7 @@ mlops\_codex.base.BaseMLOps
    :show-inheritance:
 
 
-mlops\_codex.base.BaseMLOpsClient
+BaseMLOpsClient
 ---------------------------------------------------
 
 .. autoclass:: mlops_codex.base.BaseMLOpsClient
@@ -23,7 +23,7 @@ mlops\_codex.base.BaseMLOpsClient
    :show-inheritance:
 
 
-mlops\_codex.base.MLOpsExecution
+MLOpsExecution
 --------------------------------------------------
 
 .. autoclass:: mlops_codex.base.MLOpsExecution

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,13 @@ release = '1.0.4'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [ 'sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.napoleon', 'm2r2', 'sphinx.ext.autosectionlabel',]
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
+    'm2r2',
+    'sphinx.ext.autosectionlabel',
+]
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth=3
 
@@ -41,6 +47,8 @@ templates_path = ['_templates']
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['sphinx.ext.autodoc']
+pygments_style = 'sphinx'
+highlight_language = "python"
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,8 +69,8 @@ html_theme_options = {
             # Add additional attributes to the href link.
             # The defaults of target, rel, class, title and href may be overwritten.
             "attributes": {
-               "target" : "_blank",
-               "rel" : "noopener me",
+               "target": "_blank",
+               "rel": "noopener me",
                "class": "nav-link custom-fancy-css"
             }
         },

--- a/docs/source/connecting_datasource.rst
+++ b/docs/source/connecting_datasource.rst
@@ -1,10 +1,11 @@
-Data Source
+Connecting to a Data Source
 ===========
 
 It is possible to connect a cloud provider to MLOps. The cloud provider is a source of data, where you can store and get the data that is saved data to create/perform models.
 
 Currently, MLOps supports the following providers:
-* Google GCP 
+
+* Google GCP
 * AWS S3
 * Azure Blob Storage
 
@@ -13,7 +14,8 @@ Register a data source
 
 To register your data source to MLOps, you must have the provider credentials access json, data source name and group name:
 
-.. code:: python
+.. code-block:: python
+
     client = MLOpsDataSourceClient()
     client.register_datasource(
         datasource_name='MyDataSourceName',
@@ -25,13 +27,15 @@ To register your data source to MLOps, you must have the provider credentials ac
 
 If you already have a registered data source and want to get that, you can do as following:
 
-.. code:: python
+.. code-block:: python
+
     datasource = client.get_datasource(datasource_name='testeDataSource', provider='GCP', group='datarisk')
 
 
 Once you're connected to MLOps and registered your data source, you can list the available data sources:
 
-.. code:: python
+.. code-block:: python
+
     client.list_datasource(provider='GCP', group='datarisk')
 
 
@@ -42,7 +46,8 @@ Now, you already have access to a data source, it allows you to import a data se
 
 You can import a data set via url:
 
-.. code:: python
+.. code-block:: python
+
     dataset_uri = 'https://storage.cloud.google.com/projeto/arquivo.csv'
 
     dataset = datasource.import_dataset(
@@ -54,7 +59,8 @@ It generates a DHash
 
 If you already connected your data source to MLOps and imported a data set, you can get your data set using DHash:
 
-.. code:: python
+.. code-block:: python
+
     dataset = datasource.get_dataset(dataset_hash='D66c8bc440dc4882bfeff40c0dac11641c3583f3aa274293b15ed5db21000b49')
 
 
@@ -63,5 +69,6 @@ Deleting data source and Data set
 
 If you want to remove a data source or a data set, you can do as the following example:
 
-.. code:: python
+.. code-block:: python
+
     datasource.delete()

--- a/docs/source/connecting_datasource.rst
+++ b/docs/source/connecting_datasource.rst
@@ -15,10 +15,6 @@ To register your data source to MLOps, you must have the provider credentials ac
 
 .. code:: python
     client = MLOpsDataSourceClient()
-
-    # >>> 2024-03-20 19:19:35.385 | INFO     | mlops_codex.base:__init__:20 - Loading .env
-    # >>> 2024-03-20 19:19:37.219 | INFO     | mlops_codex.base:__init__:30 - Successfully connected to MLOps
-
     client.register_datasource(
         datasource_name='MyDataSourceName',
         provider='GCP',
@@ -26,26 +22,17 @@ To register your data source to MLOps, you must have the provider credentials ac
         group='my_group'
     )
 
-    # >>> 2024-03-20 19:19:43.230 | INFO     | mlops_codex.base:__init__:20 - Loading .env
-    # >>> 2024-03-20 19:19:43.238 | INFO     | mlops_codex.base:__init__:30 - Successfully connected to MLOps
-    # >>> 2024-03-20 19:19:44.777 | INFO     | mlops_codex.datasources:register_datasource:101 - DataSource 'testeDataSouce' was registered!
 
 If you already have a registered data source and want to get that, you can do as following:
 
 .. code:: python
     datasource = client.get_datasource(datasource_name='testeDataSource', provider='GCP', group='datarisk')
-    # >>> 2024-03-20 19:19:50.600 | INFO     | mlops_codex.base:__init__:20 - Loading .env
-    # >>> 2024-03-20 19:19:50.604 | INFO     | mlops_codex.base:__init__:30 - Successfully connected to MLOps
 
 
 Once you're connected to MLOps and registered your data source, you can list the available data sources:
 
 .. code:: python
     client.list_datasource(provider='GCP', group='datarisk')
-    # >>> [{'Name': 'testeDataSouce',
-    # >>> 'Group': 'datarisk',
-    # >>> 'Provider': 'GCP',
-    # >>>'RegisteredAt': '2024-03-20T22:19:44.745936+00:00'}]
 
 
 Importing a data set 
@@ -63,19 +50,12 @@ You can import a data set via url:
         dataset_name='meudatasetcorreto'
     )
 
-    # >>> 2024-03-20 19:19:58.408 | INFO     | mlops_codex.datasources:import_dataset:279 - Datasource testeDataSource import process started! Use the D66c8bc440dc4882bfeff40c0dac11641c3583f3aa274293b15ed5db21000b49 on the `/api/datasets/status` endpoint to check it's status.
-    # >>> 2024-03-20 19:19:58.410 | INFO     | mlops_codex.base:__init__:20 - Loading .env
-    # >>> 2024-03-20 19:19:58.415 | INFO     | mlops_codex.base:__init__:30 - Successfully connected to MLOps
-
 It generates a DHash
 
 If you already connected your data source to MLOps and imported a data set, you can get your data set using DHash:
 
 .. code:: python
     dataset = datasource.get_dataset(dataset_hash='D66c8bc440dc4882bfeff40c0dac11641c3583f3aa274293b15ed5db21000b49')
-
-    # >>> 2024-03-20 19:20:16.688 | INFO     | mlops_codex.base:__init__:20 - Loading .env
-    # >>> 2024-03-20 19:20:16.692 | INFO     | mlops_codex.base:__init__:30 - Successfully connected to MLOps
 
 
 Deleting data source and Data set
@@ -85,8 +65,3 @@ If you want to remove a data source or a data set, you can do as the following e
 
 .. code:: python
     datasource.delete()
-    # >>> 2024-03-20 19:20:23.980 | INFO     | mlops_codex.datasources:delete:347 - DataSource testeDataSouce was deleted!
-
-.. code:: python
-    dataset.delete()
-    # >>> 2024-03-20 19:20:21.864 | INFO     | mlops_codex.datasources:delete:468 - Dataset removed

--- a/docs/source/connecting_to_mlops.rst
+++ b/docs/source/connecting_to_mlops.rst
@@ -3,17 +3,35 @@ Connecting to MLOps
 
 For interacting with MLOps we need to access the clients. 
 
-We have 3 of them: :py:class:`mlops_codex.training.MLOpsTrainingClient`, :py:class:`mlops_codex.model.MLOpsModelClient` and :py:class:`mlops_codex.datasource.MLOpsDataSourceClient`.
+To interact with the MLOps platform, you will need to access the provided clients.  
+
+**MLOps Codex** offers three primary clients:  
+
+- :py:class:`mlops_codex.training.MLOpsTrainingClient`  
+  Used for accessing and managing the training of Machine Learning models.
+
+- :py:class:`mlops_codex.model.MLOpsModelClient`  
+  Designed for handling model-related operations, including deployment and monitoring.  
+
+- :py:class:`mlops_codex.datasources.MLOpsDataSourceClient`
+  Enables integration and management of data sources for your ML workflows.
+
+- :py:class:`mlops_codex.preprocessing.MLOpsPreprocessingClient`
+  Provides tools for managing and automating data preprocessing tasks in Machine Learning workflows.
+
+- :py:class:`mlops_codex.external_monitoring.MLOpsExternalMonitoringClient`
+  Enables monitoring of deployed Machine Learning models trained on your own machine.
+
 
 You need the server URL, an email and a password to access the MLOps. The best way to do it is using a *.env* file with the following env variables
 
-.. code::
+.. code-block:: env
 
     MLOPS_URL='https://neomaril.datarisk.net'
     MLOPS_USER='email@email.com'
     MLOPS_PASSWORD='password@123'
 
-If you create this file in the same directory your are running your code we will import it automatically
+If you create the `.env` file in the same directory where you are running your code, it will be automatically imported.
 
 .. code:: python
 
@@ -21,49 +39,45 @@ If you create this file in the same directory your are running your code we will
     from mlops_codex.model import MLOpsModelClient
     from mlops_codex.training import MLOpsTrainingClient
     from mlops_codex.datasources import MLOpsDataSourceClient
+    from mlops_codex.preprocessing import MLOpsPreprocessingClient
+    from mlops_codex.external_monitoring import MLOpsExternalMonitoringClient
 
     # Start the client via model client
     model_client = MLOpsModelClient()
-    #>>> 2023-10-25 08:37:50.465 | INFO     | mlops_codex.model:__init__:722 - Loading .env
-    #>>> 2023-10-25 08:37:50.466 | INFO     | mlops_codex.base:__init__:90 - Loading .env
-    #>>> 2023-10-25 08:37:52.698 | INFO     | mlops_codex.base:__init__:102 - Successfully connected to MLOps
 
     # Start the client via training client
     training_client = MLOpsTrainingClient()
-    #>>> 2023-05-24 10:58:24.855 | INFO     | mlops_codex.base:__init__:87 - Loading .env
-    #>>> 2023-05-24 10:58:25.028 | INFO     | mlops_codex.base:__init__:99 - Successfully connected to MLOps
-    #>>> 2023-05-24 10:58:25.028 | INFO     | mlops_codex.base:__init__:102 - Successfully connected to MLOps
 
     # Start the client via data source client
     datasource_client = MLOpsDataSourceClient()
-    #>>> 2024-03-20 19:19:35.385 | INFO     | mlops_codex.base:__init__:20 - Loading .env
-    #>>> 2024-03-20 19:19:37.219 | INFO     | mlops_codex.base:__init__:30 - Successfully connected to MLOps
+
+    # Start the client via preprocessing client
+    preprocessing_client = MLOpsPreprocessingClient()
+
+    # Start the client via external monitoring client
+    external_monitoring_client = MLOpsExternalMonitoringClient()
+
 
 Creating a group
 ----------------
 
-Groups are a way to separate training experiments and models that might have different end-users. 
-We use it to organize the file system and network in a way that we can create a isolated process for a group. When a group is created a unique token is created to it, this is used to run the models and also increase the security of the platform.
+Groups provide a way to organize training experiments and models that may have different end-users or purposes, enabling the creation of isolated environments for each group. When a group is created, a unique token is generated, which is used to run models and enhance platform security. This token will expire after one year.
+Every resource you create in MLOps should belong to a group, making the creation of a group the first step in your workflow.
+You can create a group using any of the available clients, simply by providing its name and a description to the group for better clarity and organization.
 
-Every resource you create in MLOps should be in a group, so creating one should be the first thing you do.
 
-To create a group you can use any client, we just need its name. But we also could add description to it.
+.. code-block:: python
 
-.. code:: python
-
-   # Import the client
+    # Import the client
     from mlops_codex.training import MLOpsTrainingClient
 
-    model_client = MLOpsModelClient()
+    training_client = MLOpsTrainingClient()
 
-    model_client.create_group(
-        name='nb_demo', # Group name
-        description='Group for the demo' # A small description
+    training_client.create_group(
+        name='nb_demo',
+        description='Group for the demo'
     )
 
-    #>>> 2023-05-24 10:58:25.634 | INFO     | mlops_codex.base:create_group:155 - Group 'nb_demo' inserted. Use the following token for scoring: 'f376c18092314246a432a2882c3cc8fd'. Carefully save it as we won't show it again.' 
-
-    # We create a separate group token to be used in model predictions, so it can be shared with the clients
     # This token has a 1 year expiration date, to generate a new one use the refresh method
 
     model_client.refresh_group_token(
@@ -73,5 +87,6 @@ To create a group you can use any client, we just need its name. But we also cou
 
 Add your group token to the *.env* file:
 
-.. code::
+.. code-block:: txt
+
     MLOPS_GROUP_TOKEN='YOUR_GROUP_TOKEN'

--- a/docs/source/datasource.rst
+++ b/docs/source/datasource.rst
@@ -3,7 +3,7 @@ DataSource module
 
 Module with all classes and methods to manage the data sources and data sets 
 
-mlops\_codex.datasources.MLOpsDataSourceClient
+MLOpsDataSourceClient
 ---------------------------------------------------
 
 .. autoclass:: mlops_codex.datasources.MLOpsDataSourceClient
@@ -12,7 +12,7 @@ mlops\_codex.datasources.MLOpsDataSourceClient
     :show-inheritance:
 
 
-mlops\_codex.datasources.MLOpsDataSource
+MLOpsDataSource
 ---------------------------------------------
 
 .. autoclass:: mlops_codex.datasources.MLOpsDataSourceClient
@@ -21,7 +21,7 @@ mlops\_codex.datasources.MLOpsDataSource
     :show-inheritance:
 
 
-mlops\_codex.datasources.MLOpsDataset
+MLOpsDataset
 ------------------------------------------
 
 .. autoclass:: mlops_codex.datasources.MLOpsDataset

--- a/docs/source/exceptions.rst
+++ b/docs/source/exceptions.rst
@@ -5,7 +5,7 @@ Exceptions module
 Module that has all classes to deal with exceptions during the use of the package.
 
 
-mlops\_codex.exceptions
+Exceptions
 --------------------------
 
 .. automodule:: mlops_codex.exceptions

--- a/docs/source/external_monitoring.rst
+++ b/docs/source/external_monitoring.rst
@@ -1,0 +1,24 @@
+External Monitoring module
+===============================
+
+Module with all classes and methods to manage the Monitored External Machine Learning (ML) models.
+
+
+MLOpsExternalMonitoring
+--------------------------------------------------
+
+.. autoclass:: mlops_codex.external_monitoring.MLOpsExternalMonitoring
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: ExternalMonitoringData, validate
+
+
+MLOpsExternalMonitoringClient
+---------------------------------------------------
+
+.. autoclass:: mlops_codex.external_monitoring.MLOpsExternalMonitoringClient
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: ExternalMonitoringData, validate

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,11 +6,9 @@
 MLOps Codex
 ==============
 
-Its a Package for interacting with MLOps.
-Datarisk MLOps is an platform for Machine Learning (ML) models management, allowing the users to train, deploy and monitor those models.
-The users will need to host its Python scripts and notebooks to MLOps Codex to use the MLOps API.
-
-
+MLOps Codex is a Python package designed to facilitate interaction with MLOps platforms.
+Datarisk MLOps is a comprehensive platform for managing Machine Learning (ML) models, enabling users to seamlessly train, deploy, and monitor their models.
+To utilize the MLOps API, users must host their Python scripts and notebooks within the MLOps Codex environment.
 
 Installation
 ---------------
@@ -45,7 +43,7 @@ All classes and functions exposed in mlops_codex.* namespace are public.
 
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 3
    :caption: Docs:
 
    mlops_codex

--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -6,7 +6,7 @@ MLOps has a log parser that clean logs and tries to find useful information. Thi
 Since there are a lot of logger types is hard to create the perfect parser, so using this one helps your model script being parsed by MLOps and sending cleaner messages.
 
 
-mlops\_codex.logging.Logger
+Logger
 ------------------------------
 
 .. autoclass:: mlops_codex.logging.Logger

--- a/docs/source/mlops_codex.rst
+++ b/docs/source/mlops_codex.rst
@@ -1,49 +1,54 @@
 mlops\_codex package
 =======================
 
-The mlops_codex is a package developed by Datarisk to help people who works with ML to train, deploy, monitor and manage their models.
-This page gives an overview of all objects, functions and methods present at the package.
+The mlops_codex is a package created by Datarisk to assist those working with machine learning in training, deploying, monitoring, and managing their models.
+This page provides an overview of all the objects, functions, and methods included in the package.
 
 
 Modules
 ~~~~~~~
 
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 2
 
    base
 
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 2
 
    model
 
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 2
 
    training
 
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 2
+
+   external_monitoring
+
+.. toctree::
+   :maxdepth: 2
 
    datasource
 
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 2
 
    preprocessing
 
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 2
 
    pipeline
 
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 2
 
    logging
 
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 2
 
    exceptions

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -5,7 +5,7 @@ Model module
 Module with all classes and methods to manage the Machine Learning (ML) models deployed at MLOps.
 
 
-mlops\_codex.model.MLOpsModel
+MLOpsModel
 -----------------------------------
 
 .. autoclass:: mlops_codex.model.MLOpsModel
@@ -14,7 +14,7 @@ mlops\_codex.model.MLOpsModel
    :show-inheritance:
 
 
-mlops\_codex.model.MLOpsModelClient
+MLOpsModelClient
 -----------------------------------------
 
 .. autoclass:: mlops_codex.model.MLOpsModelClient

--- a/docs/source/pipeline.rst
+++ b/docs/source/pipeline.rst
@@ -5,7 +5,7 @@ Pipeline module
 This module allows you to configure your model pipeline.
 
 
-mlops\_codex.pipeline.MLOpsPipeline
+MLOpsPipeline
 -----------------------------------------
 
 .. autoclass:: mlops_codex.pipeline.MLOpsPipeline

--- a/docs/source/preprocessing.rst
+++ b/docs/source/preprocessing.rst
@@ -5,7 +5,7 @@ Preprocessing module
 Module with all classes and methods to manage the Preprocessing scripts deployed at MLOps.
 
 
-mlops\_codex.preprocessing.MLOpsPreprocessing
+MLOpsPreprocessing
 ---------------------------------------------------------
 
 .. autoclass:: mlops_codex.preprocessing.MLOpsPreprocessing
@@ -14,7 +14,7 @@ mlops\_codex.preprocessing.MLOpsPreprocessing
    :show-inheritance:
 
 
-mlops\_codex.preprocessing.MLOpsPreprocessingClient
+MLOpsPreprocessingClient
 ------------------------------------------------------------
 
 .. autoclass:: mlops_codex.preprocessing.MLOpsPreprocessingClient

--- a/docs/source/starters.rst
+++ b/docs/source/starters.rst
@@ -1,11 +1,15 @@
 Starters Guide
 ===============
 
-Get started on using MLOps.
+Welcome to the **MLOps Codex** starter's guide. 
+This guide is designed to help you quickly get up to speed with the library and begin integrating it into your Machine Learning workflows. 
+Whether you're new to MLOps Codex or looking to deepen your understanding, 
+this guide will provide step-by-step instructions and practical examples to streamline your journey.
+
 
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    
    connecting_to_mlops
    training_guide

--- a/docs/source/starters.rst
+++ b/docs/source/starters.rst
@@ -13,4 +13,5 @@ this guide will provide step-by-step instructions and practical examples to stre
    
    connecting_to_mlops
    training_guide
+   connecting_datasource
    deploying

--- a/docs/source/training.rst
+++ b/docs/source/training.rst
@@ -5,7 +5,7 @@ Training module
 Module with the classes that allows to manage your training experiments.
 
 
-mlops\_codex.training.MLOpsTrainingExecution
+MLOpsTrainingExecution
 --------------------------------------------------
 
 .. autoclass:: mlops_codex.training.MLOpsTrainingExecution
@@ -14,7 +14,7 @@ mlops\_codex.training.MLOpsTrainingExecution
    :show-inheritance:
 
 
-mlops\_codex.training.MLOpsTrainingExperiment
+MLOpsTrainingExperiment
 ---------------------------------------------------
 
 .. autoclass:: mlops_codex.training.MLOpsTrainingExperiment
@@ -23,7 +23,7 @@ mlops\_codex.training.MLOpsTrainingExperiment
    :show-inheritance:
 
 
-mlops\_codex.training.MLOpsTrainingClient
+MLOpsTrainingClient
 --------------------------------------------------
 
 .. autoclass:: mlops_codex.training.MLOpsTrainingClient

--- a/docs/source/training_guide.rst
+++ b/docs/source/training_guide.rst
@@ -231,7 +231,7 @@ See an example of the a configuration file:
     }
 
 
-Running an AutoML training execution
+Saving a local training to MLOps
 ----------------------------
 
 See the example below, using a python script to perform and save an External training:

--- a/docs/source/training_guide.rst
+++ b/docs/source/training_guide.rst
@@ -1,108 +1,180 @@
 Training your model
 ===================
 
-Training your model in MLOps helps by logging everything in a model registry, while also saving time by running experiments in parallel.
+Training your model in MLOps provides several benefits, including logging all activities in a model registry and improving efficiency by enabling parallel experiment runs.
 
-Also, the training module is connected to the deploying and monitoring module, so using the training in MLOps saves time in the next steps.
+Additionally, the training module is integrated with the deployment and monitoring modules, allowing you to seamlessly transition from training to deployment and monitoring, saving valuable time in the overall process.
+
+First we need to create a training experiment. We aggregate multiple train runs into one training experiment. Each train run can eventually became a deployed model or not.
+
+A training experiment requires the following key components:
+
+- **Experiment Name**: A unique identifier for your training experiment.
+- **Training Type**: The method used to train the model.
+- **Model Type**: The type of model being trained.
 
 
 Training types
 ---------------
 
-First we need to create a training experiment. We aggregate multiple train runs into one training experiment. Each train run can eventually became a deployed model or not.
+The available options for training types are:
 
-**Custom:** Is when the user will define the whole training code and define the training environment.
+- **Custom:** Is when the user will define the whole training code and define the training environment.
 
-**AutoML:** Is when the training is pre defined using the AutoML module. The required files are the training data and some configuration parameters for the package.
+- **AutoML:** Is when the training is pre defined using the AutoML module. The required files are the training data and some configuration parameters for the package.
 
-**External:** Is when you perform the model training on your machine or any other place, external to MLOps. You need to upload it, if you want to monitor your model in our environment.
+- **External:** Is when you perform the model training on your machine or any other place, external to MLOps. You need to upload it, if you want to monitor your model in our environment.
+
+
+Model Type
+----------
+
+The  parameter specifies the type of model you are training.
+
+The available options for model types are:
+
+- **Classification:** Used for training models that classify data into predefined categories. It is typically used in tasks such as image classification, text categorization, or binary classification.
+
+- **Regression:** Used for training models that predict continuous numeric values. This model type is suitable for tasks like predicting prices, sales, or any task where the output is a continuous variable.
+
+- **Unsupervised:** Used for training models that discover patterns in data without labeled outcomes. Common use cases include clustering, anomaly detection, and dimensionality reduction.
+
 
 Creating the training experiment
 --------------------------------
 
 We can create the experiment using the :py:meth:`mlops_codex.training.MLOpsTrainingClient.create_training_experiment` method.
 
-.. code:: python
+.. code-block:: python
+
+    # Import the client
+    from mlops_codex.training import MLOpsTrainingClient
 
     # Start the client
-    training_client =  MLOpsTrainingClient()
+    training_client = MLOpsTrainingClient()
 
     # Creating a new training experiment
     training = training_client.create_training_experiment(
-        experiment_name='Teste notebook', # Experiment name, this is how you find your model in MLFLow
-        model_type='Classification', # Model type. Can be Classification, Regression or Unsupervised
-        group='datarisk' # This is the default group. Create a new one when using for a new project
+        experiment_name='Teste notebook',
+        model_type='Classification',
+        group='datarisk',
+        force=False
     )
 
 
-The return of the method is a :py:class:`mlops_codex.training.MLOpsTrainingExperiment`, where you can create multiple executions that works like versions of the main experiment.
-Then you need to actually upload a dataset and a training code for your execution (if is a Custom experiment) or the configuration (for the AutoML experiment).
 
-Running a training execution
+The method returns an instance of the class :py:class:`mlops_codex.training.MLOpsTrainingExperiment`, which allows you to create multiple executions that function as versions of the main experiment.
+You must upload a dataset and your python script for your execution if it is a Custom experiment, or provide the configuration for the AutoML experiment.
+
+
+Running a custom training execution
 ----------------------------
 
 For the custom experiment you need a entrypoint function like this:
 
-.. code:: python
+.. code-block:: python
+
     import pandas as pd
     from lightgbm import LGBMClassifier
     from sklearn.impute import SimpleImputer
     from sklearn.pipeline import make_pipeline
     from sklearn.model_selection import cross_val_score
     import os
-    
-    # Function that provides the steps to train the model based on a given dataset.
-    # Its name (train_model) must be passed in the 'training_reference' field
-    # Its parameter (base_path) must contain the folder path for the files that will be used.
-    # An example for its value is: "/path/to/treino/customizado/experimento1"
-    def train_model(base_path): 
 
-        # Environment variables loaded from a user-supplied file in the 'env' field
+    def train_model(df: pd.DataFrame, base_path: str): # The function name (train_model) should be passed in the 'Method to be called' field
+        """
+        Function used to train the model based on a provided dataset.
+        This function should structure the steps that MLOps will have to execute in order to return the
+        set of information resulting from the model training.
+
+        In the function, the user can use environment variables loaded from a .env file,
+        as shown in the code on lines 59-62.
+        If the user does not want to keep the dataset name fixed, MLOps loads the name of the file
+        in the environment variable (example on lines 64-65):
+        inputFileName : str
+            This variable contains the name of the dataset file that was uploaded.
+
+        Parameters
+        ---------
+        df: pd.Dataframe
+            The pandas dataframe that will be manipulated.
+            This value is mandatory.
+
+        base_path : str
+            The folder path for the files that will be used.
+            The user can use a default value for local tests, but in MLOps, the remote file path will be used.
+            For example: "/path/to/custom_training/experiment1"
+
+        Returns
+        -------
+        dict:
+            A dictionary containing the following keys:
+            X_train: DataFrame
+                The data that will be used to train the model.
+            y_train: DataFrame
+                The dataframe/array/series of targets that will be used to train the model.
+            model_output: DataFrame
+                The dataframe/array/series with the results from the trained model.
+                This could be predicted values/probabilities, classes, or any other useful information.
+                This information must be in the model output to be used in future monitoring.
+            pipeline: Pipeline
+                The instance of the final trained model.
+                Ideally, it should be a Scikit-Learn Pipeline class, but any algorithm class that
+                implements the get_params method will work.
+                This will be saved as model.pkl with cloudpickle <https://github.com/cloudpipe/cloudpickle> or using the
+                save_model method if the algorithm class supports it.
+            metrics: dict
+                A dictionary with each key being a metric name.
+                The user can use any name for the metric key and save as many as desired,
+                but the value should be numeric.
+                For example: {"auc_train": 0.7, "auc_test": 0.65}
+            extra: string list
+                An optional list of filenames for additional files generated during training.
+                These could be graphs, validation sets, etc. They need to be saved in the same path (base_path)
+                provided as a parameter to the function.
+        """
+
+        ## Environment variables loaded from a file provided by the user in the field
+        ## 'File with environment variables' in step 3 (Optional additional files)
         # my_var = os.getenv('MY_VAR')
         # if my_var is None:
-        #   raise Exception("Could not find `env` variable")
+        #    raise Exception("Could not find `env` variable")
 
-        ## Environment variable loaded from MLOps with database name (used alternatively to line 61)
-        # df = pd.read_csv(base_path+'/'+os.getenv('inputFileName'))
-        df = pd.read_csv(base_path+"/data.csv")    # Load the database (data.csv) which must have the same name
-                                                    # file sent to MLOps in the 'train_data' field
-        
-        # The data sent must be the complete data for training and validation (excluding the validation sample),
-        # it is at the user's discretion how to treat the data here
-        X = df.drop(columns=['target'])             # Separates the database from the column with the targets
-        y = df[["target"]]                          # Saves the target in a dataframe
-        
-        pipe = make_pipeline(SimpleImputer(), LGBMClassifier())     # Define the steps to train the model
-        
-        # In this example we used cross-validation, but this is at the user's discretion
+        X = df.drop(columns=['target'])             # Separates the data from the column with the targets
+        y = df[["target"]]                          # Saves the targets in a DataFrame
+
+        pipe = make_pipeline(SimpleImputer(), LGBMClassifier())     # Defines the steps to train the model
+
+        # In this example, we use cross-validation, but this is at the user's discretion
         auc = cross_val_score(pipe, X, y, cv=5, scoring="roc_auc")  # Validation of results using the 'auc' metric
         f_score = cross_val_score(pipe, X, y, cv=5, scoring="f1")   # Validation of results using the 'f1' metric
         pipe.fit(X, y)  # Train the model
 
         # Build the DataFrame with the results
-        results = pd.DataFrame({"pred": pipe.predict(X), "proba": pipe.predict_proba(X)[:,1]})  
-        
+        results = pd.DataFrame({"pred": pipe.predict(X), "proba": pipe.predict_proba(X)[:,1]})
+
         # Returns the training results according to the parameters expected by MLOps
-        return {"X_train": X, "y_train": y, "model_output": results, "pipeline": pipe, 
+        return {"X_train": X, "y_train": y, "model_output": results, "pipeline": pipe,
                 "metrics": {"auc": auc.mean(), "f1_score": f_score.mean()}}
 
+The function accepts two parameters: the dataframe containing the data and the path to the data file. This allows the function to be executed when the files are uploaded to MLOps.
+In the custom training experiment, you have full flexibility to experiment with different algorithms, optimize hyperparameters, and validate the model on multiple segments of the data.
+The critical part is the function's return value, which provides information about the final model for logging and monitoring purposes. The return must be a dictionary containing the following keys:
 
-The only parameter on the function is the path for the data file. This way we can execute it when the files are uploaded to MLOps.
-In the custom training experiment you can do whatever you want, test multiple algorithms, optimize hyperparameters, validate on multiple segments of the data.
-The important thing is the return of the function, where we get information about the final model of this version so we can log it. The return must be a dictionary with the following keys:
+- **X_train**: The dataframe that will be used to fit the model.
+- **y_train**: The target dataframe/array/series that will be used to fit the model.
+- **model_output**: A dataframe/array/series with the outputs of the trained model, such as predicted values, probabilities, or classes. This information must be included in the output of the deployed model to facilitate monitoring.
+- **pipeline**: The final, fitted model instance. Ideally, this should be a `Scikit-Learn Pipeline Class <https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html>`_, but any other algorithm class that implements the get_params method will also work. This will be saved as model.pkl using `cloudpickle <https://github.com/cloudpipe/cloudpickle>`_ or the save_model method, if the algorithm class provides that.
+- **extra (optional)**: A list of filenames for any additional files generated during training, such as plots, validation datasets, or logs. These files should be saved in the same path provided as the function parameter.
+- **metrics**: A dictionary with metric names as keys and numeric values as the metrics (e.g., {"auc_train": 0.7, "auc_test": 0.65}). You can include as many metrics as needed, but each value must be a number.
 
-- `X_train`: The dataframe that will be used to fit the model.
-- `y_train`: The target dataframe/array/series that will be used to fit the model.
-- `model_output`: A dataframe/array/series with outputs of the model. This can be the predicted values/probabilities, classes or any other useful information. This information needs to be in the output of the future deployed model to be used in the monitoring
-- `pipeline`: The final fitted model instance. Ideally it should be a `Scikit-Learn Pipeline Class <https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html>`_, but any other algorithm class that has the *get_params* method implemented works. This will be saved as `model.pkl` with `cloudpickle <https://github.com/cloudpipe/cloudpickle> _` or with the `save_model` method if the algorithm class has that.
-- `extra`: A optional list of filenames for extra files that are generated in the training. This can be plots, validation datasets, etc. They need to be saved in the same path that is provided as the function parameter.
-- `metrics`: A dictionary with each key as a metric. You can use any name for the metric key and save as many as you want, but the value must be numeric. Eg: `{"auc_train": 0.7, "auc_test": 0;65}`
+Additionally, we also need environment information, such as the Python version and package requirements, to ensure compatibility and reproducibility of the training process.
 
-Besides that we also need the information for the environment (python version and package requirements). 
+This structure ensures that all relevant details are logged and available for monitoring in MLOps, making the model's lifecycle transparent and manageable.
 
-Then we can call the :py:meth:`mlops_codex.training.MLOpsTrainingExperiment.run_training` method.
+Then we can call the :py:meth:`mlops_codex.training.MLOpsTrainingExperiment.run_training` method:
 
-.. code:: python
+.. code-block:: python
 
     # With the experiment class we can create multiple model runs
     PATH = './samples/train/'
@@ -120,9 +192,13 @@ Then we can call the :py:meth:`mlops_codex.training.MLOpsTrainingExperiment.run_
         wait_complete=True
     )
 
+
+Running an AutoML training execution
+----------------------------
+
 For the AutoML we just need the data and the configuration parameters. You can check the :doc:`automl_parameters` for more details. 
 
-.. code:: python
+.. code-block:: python
 
     PATH = './samples/autoML/'
 
@@ -134,9 +210,34 @@ For the AutoML we just need the data and the configuration parameters. You can c
         wait_complete=True
     )
 
+See an example of the a configuration file:
+
+.. code-block:: json
+
+    {
+        "train_data": {
+            "file_type": "csv",
+            "sep": ",",
+            "file_name": "dados.csv"
+        },
+        "model_flow": "classification",
+        "target": "target",
+        "iterations": 1,
+        "metric": "ks",
+        "split_type": "random",
+        "stages": {
+            "models": ["logreg"]
+            }
+    }
+
+
+Running an AutoML training execution
+----------------------------
+
 See the example below, using a python script to perform and save an External training:
 
-.. code:: python
+.. code-block:: python
+
     from mlops_codex.training import MLOpsTrainingClient
     import pandas as pd
     from lightgbm import LGBMClassifier
@@ -197,35 +298,18 @@ See the example below, using a python script to perform and save an External tra
 Checking the execution results
 ------------------------------
 
-The return of the :py:meth:`mlops_codex.training.MLOpsTrainingExperiment.run_training` is a :py:class:`mlops_codex.training.MLOpsTrainingExecution` instance
-With this class we can follow the asynchronous execution of that experiment version and check information on it. 
+The :py:meth:`mlops_codex.training.MLOpsTrainingExperiment.run_training` method returns an instance of the :py:class:`mlops_codex.training.MLOpsTrainingExecution` class.
+This class allows you to monitor the asynchronous execution of the specified experiment version and retrieve detailed information about its progress and status.
 
-.. code:: python
+.. code-block:: python
 
     run1.get_status()
-
-    #>>> {'trainingExecutionId': '3', 'Status': 'Running', 'Message': None}
-
-    run1.execution_data
-
-    #>>> {'TrainingHash': 'T48c2371e453418f9859aba957de85cbcf84928d62a048b48f0259b49054a639',
-    #     'ExperimentName': 'Teste notebook Training custom',
-    #     'GroupName': 'datarisk',
-    #     'ModelType': 'Classification',
-    #     'TrainingType': 'Custom',
-    #     'ExecutionId': 3,
-    #     'ExecutionState': 'Running',
-    #     'RunData': {},
-    #     'RunAt': '2023-05-25T17:37:07.8850840Z',
-    #     'Status': 'Requested'}
-
+    run1.execution_info()
 
 We can also download the results (model file and files saved in the `extra` key)
 
-.. code:: python
+.. code-block:: python
 
     run1.download_result()
-    
-    #>>> 2023-05-26 10:02:13.441 | INFO     | mlops_codex.base:download_result:376 - Output saved in ./output_2.zip
 
 If the model is good enough we can start the deploying process.

--- a/notebooks/samples/syncPreprocessing/app.py
+++ b/notebooks/samples/syncPreprocessing/app.py
@@ -9,9 +9,9 @@ def process(data:str, base_path:str): # O nome da função (process) é que deve
     
     Parâmetros
     ---------
-    data : str
+    data: str
         Os dados que serão usados pelo modelo que deverão chegar no formato string
-    base_path : str
+    base_path: str
         O caminho para o arquivo do modelo e outros arquivos complementares
 
     Retorno

--- a/notebooks/samples/train/app.py
+++ b/notebooks/samples/train/app.py
@@ -15,7 +15,7 @@ def train_model(df: pd.DataFrame, base_path:str): # O nome da função (train_mo
     como exemplificado no código nas linhas 59-62.
     Caso não queira deixar o nome da base de dados fixo, o MLOps carrega o nome desse arquivo
     na variável de ambiente (exemplo nas linhas 64-65):
-    inputFileName : str
+    inputFileName: str
         Que contém o nome do arquivo da base de dados que foi feito upload
 
 
@@ -24,7 +24,7 @@ def train_model(df: pd.DataFrame, base_path:str): # O nome da função (train_mo
     df: pd.Dataframe
         Pandas dataframe que será manipulado.
         Esse valor é obrigatório
-    base_path : str
+    base_path: str
         O caminho de pastas para os arquivos que serão usados. 
         O usuário pode usar um valor default para testes locais, mas no MLOps será usado o caminho 
         remoto dos arquivos.

--- a/src/mlops_codex/base.py
+++ b/src/mlops_codex/base.py
@@ -132,11 +132,11 @@ class BaseMLOpsClient(BaseMLOps):
 
     Parameters
     ----------
-    login : str
+    login: str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
-    url : str
+    url: str
         URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
@@ -215,9 +215,9 @@ class BaseMLOpsClient(BaseMLOps):
 
         Parameters
         ----------
-        name : str
+        name: str
             Name of the group. Must be 32 characters long and with no special characters (some parsing will be made)
-        description : str
+        description: str
             Short description of the group
 
         Raises
@@ -283,9 +283,9 @@ class BaseMLOpsClient(BaseMLOps):
 
         Parameters
         ---------
-        name : str
+        name: str
             Name of the group to have the token refreshed
-        force : bool
+        force: bool
             Force token expiration even if it's still valid (this can make multiple models integrations stop working, so use with care)
 
         Raises
@@ -359,19 +359,19 @@ class MLOpsExecution(BaseMLOps):
 
     Parameters
     ----------
-    parent_id : str
+    parent_id: str
         Model id (hash) from the model you want to access
-    exec_type : str
+    exec_type: str
         Flag that contains which type of execution you use. It can be 'AsyncModel' or 'Training'
-    group : Optional[str], optional
+    group: Optional[str], optional
         Group the model is inserted
-    exec_id : Optional[str], optional
+    exec_id: Optional[str], optional
         Execution id
-    login : Optional[str], optional
+    login: Optional[str], optional
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
-    password : Optional[str], optional
+    password: Optional[str], optional
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
-    url : Optional[str], optional
+    url: Optional[str], optional
         URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
@@ -486,7 +486,7 @@ class MLOpsExecution(BaseMLOps):
         return f"""MLOps{self.exec_type}Execution(exec_id="{self.exec_id}", status="{self.status}")"""
 
     def __str__(self):
-        return f'MLOPS {self.exec_type }Execution :{self.exec_id} (Status: {self.status})"'
+        return f'MLOPS {self.exec_type }Execution:{self.exec_id} (Status: {self.status})"'
 
     def get_status(self) -> dict:
         """
@@ -551,9 +551,9 @@ class MLOpsExecution(BaseMLOps):
 
         Parameters
         ---------
-        path : Optional[str], optional
+        path: Optional[str], optional
             Path of the result file. Default value is './'
-        filename : Optional[str], optional
+        filename: Optional[str], optional
             Name of the result file. Default value is 'output.zip'
 
         Raises

--- a/src/mlops_codex/base.py
+++ b/src/mlops_codex/base.py
@@ -48,7 +48,7 @@ class BaseMLOps:
         if url is None:
             url = os.getenv("MLOPS_URL")
         if url is None:
-            url = "https://neomaril.datarisk.net/"
+            url = "https://mlops.datarisk.net/"
 
         self.credentials = (
             login if login else os.getenv("MLOPS_USER"),
@@ -130,14 +130,14 @@ class BaseMLOpsClient(BaseMLOps):
     A group is a way to organize models clustering for different users and also to increase security.
     Each group has a unique token that should be used to run the models that belongs to that.
 
-    Attributes
+    Parameters
     ----------
     login : str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
     password : str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
     url : str
-        URL to MLOps Server. Default value is https://neomaril.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
+        URL to MLOps Server. Default value is https://mlops.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
     ------
@@ -173,7 +173,7 @@ class BaseMLOpsClient(BaseMLOps):
         Returns
         -------
         list
-            List with the groups that exists in the database
+            Return groups that exists in the database
         """
 
         url = f"{self.base_url}/groups"
@@ -208,13 +208,13 @@ class BaseMLOpsClient(BaseMLOps):
         logger.error(f"Something went wrong...\n{formatted_msg}")
         raise InputError("Bad Input. Client error")
 
-    def create_group(self, *, name: str, description: str) -> bool:
+    def create_group(self, *, name: str, description: str) -> str:
         """
         Create a group for multiple models of the same final client at the end if it returns TRUE, a message with the token for that group will be returned as a INFO message.
         You should keep this token information to be able to run the model of that group afterward.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         name : str
             Name of the group. Must be 32 characters long and with no special characters (some parsing will be made)
         description : str
@@ -222,13 +222,17 @@ class BaseMLOpsClient(BaseMLOps):
 
         Raises
         ------
+        AuthenticationError
+            Raised if there is an authentication issue.
+        GroupError
+            Raised if there is an error related to the group.
         ServerError
-            Unexpected server error
+            Raised if the server encounters an issue.
 
         Returns
         -------
-        bool
-            Returns True if the group was successfully created and False if not
+        str
+            Returns the group token
         """
         data = {"name": name, "description": description}
 
@@ -271,28 +275,34 @@ class BaseMLOpsClient(BaseMLOps):
         logger.error(f"Something went wrong:\n {formatted_msg}")
         raise InputError("Bad Input. Client error")
 
-    def refresh_group_token(self, *, name: str, force: bool = False) -> bool:
+    def refresh_group_token(self, *, name: str, force: bool = False) -> str:
         """
         Refresh the group token. If the token it's still valid it won't be changed, unless you use parameter force = True.
         At the end a message with the token for that group will be returned as a INFO message.
         You should keep this new token information to be able to run the model of that group afterward.
 
-        Arguments
+        Parameters
         ---------
         name : str
             Name of the group to have the token refreshed
-        force : str
-            Force token expiration even if its still valid (this can make multiple models integrations stop working, so use with care)
+        force : bool
+            Force token expiration even if it's still valid (this can make multiple models integrations stop working, so use with care)
 
         Raises
         ------
+        AuthenticationError
+            Raised if there is an authentication issue.
+        GroupError
+            Raised if there is an error related to the group.
         ServerError
-            Unexpected server error
+            Raised if the server encounters an issue.
+        InputError
+            Something went wrong in the input
 
         Returns
         -------
-        bool
-            Returns True if the group was successfully created and False if not.
+        str
+            Returns group token.
 
         Example
         --------
@@ -347,22 +357,22 @@ class MLOpsExecution(BaseMLOps):
     """
     Base class for MLOps asynchronous model executions. With this class you can visualize the status of an execution and download the results after and execution has finished.
 
-    Attributes
+    Parameters
     ----------
-    parend_id : str
+    parent_id : str
         Model id (hash) from the model you want to access
     exec_type : str
         Flag that contains which type of execution you use. It can be 'AsyncModel' or 'Training'
-    group : str, optional
+    group : Optional[str], optional
         Group the model is inserted
-    exec_id : str, optional
+    exec_id : Optional[str], optional
         Execution id
-    login : str
+    login : Optional[str], optional
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
-    password : str
+    password : Optional[str], optional
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
-    url : str
-        URL to MLOps Server. Default value is https://neomaril.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
+    url : Optional[str], optional
+        URL to MLOps Server. Default value is https://mlops.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
     ------
@@ -539,22 +549,17 @@ class MLOpsExecution(BaseMLOps):
         """
         Gets the output of the execution.
 
-        Arguments
+        Parameters
         ---------
-        path : str
+        path : Optional[str], optional
             Path of the result file. Default value is './'
-        filename : str
+        filename : Optional[str], optional
             Name of the result file. Default value is 'output.zip'
 
         Raises
         ------
         ExecutionError
-            Execution unavailable
-
-        Returns
-        -------
-        dict
-            Returns the path for the result file.
+            Execution is unavailable or failed status.
         """
         if self.status in [ModelExecutionState.Running, ModelExecutionState.Requested]:
             self.status = ModelExecutionState[self.get_status()["Status"]]

--- a/src/mlops_codex/base.py
+++ b/src/mlops_codex/base.py
@@ -48,7 +48,7 @@ class BaseMLOps:
         if url is None:
             url = os.getenv("MLOPS_URL")
         if url is None:
-            url = "https://mlops.datarisk.net/"
+            url = "https://neomaril.datarisk.net/"
 
         self.credentials = (
             login if login else os.getenv("MLOPS_USER"),
@@ -137,7 +137,7 @@ class BaseMLOpsClient(BaseMLOps):
     password : str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
     url : str
-        URL to MLOps Server. Default value is https://mlops.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
+        URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
     ------
@@ -372,7 +372,7 @@ class MLOpsExecution(BaseMLOps):
     password : Optional[str], optional
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
     url : Optional[str], optional
-        URL to MLOps Server. Default value is https://mlops.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
+        URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
     ------

--- a/src/mlops_codex/datasources.py
+++ b/src/mlops_codex/datasources.py
@@ -22,7 +22,7 @@ class MLOpsDataSourceClient(BaseMLOpsClient):
     """
     Class for client for manage datasources
 
-    Attributes
+    Parameters
     ----------
     login : str
         Login for authenticating with the client.
@@ -32,12 +32,12 @@ class MLOpsDataSourceClient(BaseMLOpsClient):
         You can also use the env variable MLOPS_PASSWORD to set this
     url : str
         URL to MLOps Server.
-        Default value is https://neomaril.datarisk.net,
+        Default value is https://mlops.datarisk.net,
         use it to test your deployment first before changing to production.
         You can also use the env variable MLOPS_URL to set this
 
     Raises
-    ----------
+    ------
     ServerError
         Database produced an unexpected error.
     AuthenticationError
@@ -57,7 +57,7 @@ class MLOpsDataSourceClient(BaseMLOpsClient):
         """
         Register the user cloud credentials to allow MLOps to use the provider to download the datasource.
 
-        Attributes
+        Parameters
         ----------
         group : str
             Name of the group where we will search the datasources.
@@ -134,13 +134,21 @@ class MLOpsDataSourceClient(BaseMLOpsClient):
                 raise AuthenticationError("User is not in the master group.")
         raise CredentialError("Cloud Credential Error")
 
-    def credentials_to_json(self, input_data: dict):
+    def credentials_to_json(self, input_data: dict) -> str:
         """
         Transform dict to json.
 
-        Args:
-            input_data (dict): A dictionary to save.
+        Parameters
+        ----------
+        input_data : dict
+            A dictionary to save.
+
+        Returns
+        -------
+        str
+            Path to the credentials file.
         """
+
         path = "./credentials.json"
         with open(path, "w", encoding="utf-8") as f:
             json.dump(input_data, f)
@@ -150,11 +158,20 @@ class MLOpsDataSourceClient(BaseMLOpsClient):
         """
         List all datasources of the group with this provider type.
 
-        Attributes
+        Parameters
         ----------
         group : str
             Name of the group where we will search the datasources
         provider : str ("Azure" | "AWS" | "GCP")
+
+        Raises
+        ------
+        AuthenticationError
+            Raised if there is an authentication issue.
+        ServerError
+            Raised if the server encounters an issue.
+        InputError
+            Raised if something went wrong.
 
         Returns
         ----------
@@ -201,13 +218,14 @@ class MLOpsDataSourceClient(BaseMLOpsClient):
         """
         Get a MLOpsDataSource to make datasource operations.
 
-        Attributes
+        Parameters
         ----------
-        group : str
-            Name of the group where we will search the datasources
         datasource_name : str
             Name given previously to the datasource.
-        provider : str ("Azure" | "AWS" | "GCP")
+        provider : str
+            It can be "Azure" | "AWS" | "GCP"
+        group : str
+            Name of the group where we will search the datasources
 
         Returns
         ----------
@@ -236,7 +254,7 @@ class MLOpsDataSource(BaseMLOps):
     """
     Class to operate actions in a datasource.
 
-    Attributes
+    Parameters
     ----------
     login : str
         Login for authenticating with the client.
@@ -246,7 +264,7 @@ class MLOpsDataSource(BaseMLOps):
         You can also use the env variable MLOPS_PASSWORD to set this
     url : str
         URL to MLOps Server.
-        Default value is https://neomaril.datarisk.net,
+        Default value is https://mlops.datarisk.net/,
         use it to test your deployment first before changing to production.
         You can also use the env variable MLOPS_URL to set this
     datasource_name : str
@@ -281,7 +299,7 @@ class MLOpsDataSource(BaseMLOps):
         """
         Import a dataset inside a datasource.
 
-        Attributes
+        Parameters
         ----------
         dataset_uri : str
             Datasource cloud URI path.
@@ -297,6 +315,10 @@ class MLOpsDataSource(BaseMLOps):
 
         Raises
         ----------
+        AuthenticationError
+            Raised if there is an authentication issue.
+        ServerError
+            Raised if the server encounters an issue.
         InputError
             If any data sent is invalidated on server.
 
@@ -355,11 +377,7 @@ class MLOpsDataSource(BaseMLOps):
 
     def delete(self):
         """
-        Delete the datasource on mlops.
-        Pay attention when doing this action, it is irreversible!
-        Returns
-        -------
-        None
+        Delete the datasource on mlops. Pay attention when doing this action, it is irreversible!
 
         Example
         -------
@@ -379,11 +397,11 @@ class MLOpsDataSource(BaseMLOps):
         )
         logger.info(response.json().get("Message"))
 
-    def get_dataset(self, *, dataset_hash: str, origin: str = None):
+    def get_dataset(self, *, dataset_hash: str, origin: Optional[str] = None):
         """
         Get a MLOpsDataset to make dataset operations.
 
-        Attributes
+        Parameters
         ----------
         dataset_hash : str
             Name given previously to the datasource.
@@ -424,7 +442,7 @@ class MLOpsDataset(BaseMLOps):
     """
     Class to operate actions in a dataset.
 
-    Attributes
+    Parameters
     ----------
     login : str
         Login for authenticating with the client.
@@ -434,7 +452,7 @@ class MLOpsDataset(BaseMLOps):
         You can also use the env variable MLOPS_PASSWORD to set this
     url : str
         URL to MLOps Server.
-        Default value is https://neomaril.datarisk.net,
+        Default value is https://mlops.datarisk.net/,
         use it to test your deployment first before changing to production.
         You can also use the env variable MLOPS_URL to set this
     dataset_hash : str
@@ -528,8 +546,7 @@ class MLOpsDataset(BaseMLOps):
 
     def delete(self):
         """
-        Delete the dataset on mlops.
-        Pay attention when doing this action, it is irreversible!
+        Delete the dataset on mlops. Pay attention when doing this action, it is irreversible!
 
         Example
         ----------
@@ -577,15 +594,15 @@ class MLOpsDataset(BaseMLOps):
         """
         List datasets from datasources.
 
-        Attributes
+        Parameters
         ----------
-            origin: Optional[str]
+            origin: Optional[str], optional
                 Origin of a dataset. It can be "Training", "Preprocessing", "Datasource" or "Model"
-            origin_id: Optional[str]
+            origin_id: Optional[str], optinal
                 Integer that represents the id of a dataset, given an origin
-            datasource_name: Optional[str]
+            datasource_name: Optional[str], optinal
                 Name of the datasource
-            group: Optional[str]
+            group: Optional[str], optinal
                 Name of the group where we will search the datasource
 
         Returns

--- a/src/mlops_codex/datasources.py
+++ b/src/mlops_codex/datasources.py
@@ -24,13 +24,13 @@ class MLOpsDataSourceClient(BaseMLOpsClient):
 
     Parameters
     ----------
-    login : str
+    login: str
         Login for authenticating with the client.
         You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client.
         You can also use the env variable MLOPS_PASSWORD to set this
-    url : str
+    url: str
         URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
@@ -56,12 +56,12 @@ class MLOpsDataSourceClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        group : str
+        group: str
             Name of the group where we will search the datasources.
-        datasource_name : str
+        datasource_name: str
             Name given previously to the datasource.
-        provider : str ("Azure" | "AWS" | "GCP")
-        cloud_credentials : str | Union[dict,str]
+        provider: str ("Azure" | "AWS" | "GCP")
+        cloud_credentials: str | Union[dict,str]
             Path or dict to a JSON with the credentials to access the provider.
 
         Returns
@@ -137,7 +137,7 @@ class MLOpsDataSourceClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        input_data : dict
+        input_data: dict
             A dictionary to save.
 
         Returns
@@ -157,9 +157,9 @@ class MLOpsDataSourceClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        group : str
+        group: str
             Name of the group where we will search the datasources
-        provider : str ("Azure" | "AWS" | "GCP")
+        provider: str ("Azure" | "AWS" | "GCP")
 
         Raises
         ------
@@ -217,11 +217,11 @@ class MLOpsDataSourceClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        datasource_name : str
+        datasource_name: str
             Name given previously to the datasource.
-        provider : str
+        provider: str
             It can be "Azure" | "AWS" | "GCP"
-        group : str
+        group: str
             Name of the group where we will search the datasources
 
         Returns
@@ -253,22 +253,22 @@ class MLOpsDataSource(BaseMLOps):
 
     Parameters
     ----------
-    login : str
+    login: str
         Login for authenticating with the client.
         You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client.
         You can also use the env variable MLOPS_PASSWORD to set this
-    url : str
+    url: str
         URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
-    datasource_name : str
+    datasource_name: str
         Name given previously to the datasource.
-    provider : str
+    provider: str
         Providers name, currently, MLOps supports:
         Azure Blob Storage as "Azure",
         AWS S3 as "AWS",
         Google GCP as "GCP".
-    group : str
+    group: str
         Name of the group where we will search the datasources
     """
 
@@ -295,11 +295,11 @@ class MLOpsDataSource(BaseMLOps):
 
         Parameters
         ----------
-        dataset_uri : str
+        dataset_uri: str
             Datasource cloud URI path.
-        dataset_name : str
+        dataset_name: str
             The dataset defined name
-        force : bool
+        force: bool
             Optional[boolean]: when it is true it will force the datasource download from the provider.
 
         Returns
@@ -397,9 +397,9 @@ class MLOpsDataSource(BaseMLOps):
 
         Parameters
         ----------
-        dataset_hash : str
+        dataset_hash: str
             Name given previously to the datasource.
-        origin : Optional[str]
+        origin: Optional[str]
             Can be an EHash or a SHash
 
         Returns
@@ -438,21 +438,21 @@ class MLOpsDataset(BaseMLOps):
 
     Parameters
     ----------
-    login : str
+    login: str
         Login for authenticating with the client.
         You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client.
         You can also use the env variable MLOPS_PASSWORD to set this
-    url : str
+    url: str
         URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
-    dataset_hash : str
+    dataset_hash: str
         The hash that identify the dataset
-    dataset_name : str
+    dataset_name: str
         The dataset defined name
-    datasource_name : str
+    datasource_name: str
         Name given previously to the datasource.
-    group : str
+    group: str
         Name of the group where we will search the datasource
     """
 
@@ -482,8 +482,8 @@ class MLOpsDataset(BaseMLOps):
         dict
             when success
             {
-                status : 'Succeeded',
-                log : ''
+                status: 'Succeeded',
+                log: ''
             }
             when failed
             {

--- a/src/mlops_codex/datasources.py
+++ b/src/mlops_codex/datasources.py
@@ -31,10 +31,7 @@ class MLOpsDataSourceClient(BaseMLOpsClient):
         Password for authenticating with the client.
         You can also use the env variable MLOPS_PASSWORD to set this
     url : str
-        URL to MLOps Server.
-        Default value is https://mlops.datarisk.net,
-        use it to test your deployment first before changing to production.
-        You can also use the env variable MLOPS_URL to set this
+        URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
     ------
@@ -263,10 +260,7 @@ class MLOpsDataSource(BaseMLOps):
         Password for authenticating with the client.
         You can also use the env variable MLOPS_PASSWORD to set this
     url : str
-        URL to MLOps Server.
-        Default value is https://mlops.datarisk.net/,
-        use it to test your deployment first before changing to production.
-        You can also use the env variable MLOPS_URL to set this
+        URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
     datasource_name : str
         Name given previously to the datasource.
     provider : str
@@ -451,10 +445,7 @@ class MLOpsDataset(BaseMLOps):
         Password for authenticating with the client.
         You can also use the env variable MLOPS_PASSWORD to set this
     url : str
-        URL to MLOps Server.
-        Default value is https://mlops.datarisk.net/,
-        use it to test your deployment first before changing to production.
-        You can also use the env variable MLOPS_URL to set this
+        URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
     dataset_hash : str
         The hash that identify the dataset
     dataset_name : str

--- a/src/mlops_codex/external_monitoring.py
+++ b/src/mlops_codex/external_monitoring.py
@@ -145,17 +145,17 @@ class MLOpsExternalMonitoring(BaseMLOps):
 
         Parameters
         ----------
-        model_file : Optional[str], optional
+        model_file: Optional[str], optional
             Path to your `model.pkl` file. Defaults to None.
-        requirements_file : Optional[str], optional
+        requirements_file: Optional[str], optional
             Path to your `requirements.txt` file. Defaults to None.
-        preprocess_file : Optional[str], optional
+        preprocess_file: Optional[str], optional
             Path to your preprocessing file. Defaults to None.
-        preprocess_reference : Optional[str], optional
+        preprocess_reference: Optional[str], optional
             Preprocessing function entrypoint. Defaults to None.
-        shap_reference : Optional[str], optional
+        shap_reference: Optional[str], optional
             Shap function entrypoint. Defaults to None.
-        python_version : Optional[str], optional
+        python_version: Optional[str], optional
             Python version. Can be "3.8", "3.9", or "3.10". Defaults to "3.10".
 
         Raises
@@ -230,7 +230,7 @@ class MLOpsExternalMonitoring(BaseMLOps):
 
         Parameters
         ----------
-        wait : Optional[bool], optional
+        wait: Optional[bool], optional
             If true, wait until the host is validated or invalidate.
 
         Raises
@@ -366,9 +366,9 @@ class MLOpsExternalMonitoring(BaseMLOps):
 
         Parameters
         ----------
-        start : str
+        start: str
             Start date to look for the records. The format must be `dd-MM-yyyy`.
-        end : str
+        end: str
             End date to look for the records. The format must be `dd-MM-yyyy`.
         """
         url = f"{self.base_url}/monitoring/search/records/{self.group}/{self.ex_monitoring_hash}"
@@ -385,13 +385,13 @@ class MLOpsExternalMonitoringClient(BaseMLOpsClient):
 
     Parameters
     ----------
-    login : str
+    login: str
         Login for authenticating with the client.
         You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client.
         You can also use the env variable MLOPS_PASSWORD to set this
-    url : str
+    url: str
         URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
@@ -498,30 +498,30 @@ class MLOpsExternalMonitoringClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        name : str
+        name: str
             External Monitoring name.
-        group : str
+        group: str
             External Monitoring group. The group is the same used for the external training and datasource.
-        training_execution_id : int
+        training_execution_id: int
             Valid MLOps training execution id.
-        period : str
+        period: str
             The frequency the monitoring will run. It can be one of the following: "Day", "Week", "Quarter",
             "Month", "Year".
-        input_cols : list
+        input_cols: list
             List with input column names.
-        output_cols : list
+        output_cols: list
             List with output column names.
-        datasource_name : str
+        datasource_name: str
             Valid MLOps datasource name.
-        extraction_type : str
+        extraction_type: str
             Type of extraction. It can be one of the following: "Incremental", "Full".
-        datasource_uri : str
+        datasource_uri: str
             Valid datasource URI.
-        column_name : Optional[str], optional
+        column_name: Optional[str], optional
             Column name of the data column.
-        reference_date : Optional[str], optional
+        reference_date: Optional[str], optional
             Reference extraction date.
-        python_version : Optional[str], optional
+        python_version: Optional[str], optional
             Python version used to run preprocessing scripts. It can be one of the following: "3.8", "3.9", "3.10". Defaults to "3.10".
 
         Raises
@@ -650,7 +650,7 @@ class MLOpsExternalMonitoringClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        external_monitoring_hash : str
+        external_monitoring_hash: str
             External Monitoring Hash.
 
         Raises

--- a/src/mlops_codex/external_monitoring.py
+++ b/src/mlops_codex/external_monitoring.py
@@ -39,6 +39,17 @@ class MLOpsExternalMonitoring(BaseMLOps):
         password: Optional[str] = None,
         url: Optional[str] = None,
     ):
+        """
+        Parameters
+        ----------
+        group:
+        ex_monitoring_hash:
+        status:
+        login:
+        password:
+        url:
+        """
+
         super().__init__(login=login, password=password, url=url)
         self.external_monitoring_url = f"{self.base_url}/external-monitoring"
         self.ex_monitoring_hash = ex_monitoring_hash
@@ -129,19 +140,30 @@ class MLOpsExternalMonitoring(BaseMLOps):
         shap_reference: Optional[str] = None,
         python_version: Optional[str] = "3.10",
     ):
-        """Validate inputs before send files
+        """
+        Validate inputs before sending files.
 
-        Args:
-            model_file (Optional[str], optional): Path to your model.pkl file. Defaults to None.
-            requirements_file (Optional[str]): Path to your requirements.txt file. Defaults to None.
-            preprocess_file (Optional[str]): Path to your preprocessing file. Defaults to None.
-            preprocess_reference (Optional[str]): Preprocessing function entrypoint. Defaults to None.
-            shap_reference (Optional[str]): Shap function entrypoint. Defaults to None.
-            python_version (Optional[str], optional): Python version. Can be "3.8", "3.9" or "3.10". Defaults to "3.10".
+        Parameters
+        ----------
+        model_file : Optional[str], optional
+            Path to your `model.pkl` file. Defaults to None.
+        requirements_file : Optional[str], optional
+            Path to your `requirements.txt` file. Defaults to None.
+        preprocess_file : Optional[str], optional
+            Path to your preprocessing file. Defaults to None.
+        preprocess_reference : Optional[str], optional
+            Preprocessing function entrypoint. Defaults to None.
+        shap_reference : Optional[str], optional
+            Shap function entrypoint. Defaults to None.
+        python_version : Optional[str], optional
+            Python version. Can be "3.8", "3.9", or "3.10". Defaults to "3.10".
 
-        Raises:
-            InputError
-            InputError
+        Raises
+        ------
+        InputError
+            Raised if there is an error with the input `model_file`.
+        InputError
+            Raised if there is an error with the input `requirements_file`.
         """
 
         if model_file is not None:
@@ -203,22 +225,29 @@ class MLOpsExternalMonitoring(BaseMLOps):
                 logger.info(f"{file} file uploaded successfully")
 
     def host(self, wait: Optional[bool] = False):
-        """Host the new external monitoring
+        """
+        Host the new external monitoring.
 
-        Attributes:
-        -----------
-        url (str): Url to host the external monitoring
+        Parameters
+        ----------
+        wait : Optional[bool], optional
+            If true, wait until the host is validated or invalidate.
 
-        Raises:
-        -------
+        Raises
+        ------
         AuthenticationError
+            Raised if there is an authentication issue.
         GroupError
+            Raised if there is an error related to the group.
         ServerError
+            Raised if the server encounters an issue.
         ExternalMonitoringError
+            Raised if there is an error specific to external monitoring.
 
         Returns
         -------
-        bool: True if host the new external monitoring
+        str
+            The external monitoring hash if the new external monitoring is successfully hosted.
         """
 
         if self.status == MonitoringStatus.Validated:
@@ -263,10 +292,13 @@ class MLOpsExternalMonitoring(BaseMLOps):
         raise ExternalMonitoringError("Unknown error. Please contact administrator.")
 
     def wait_ready(self):
-        """Check the status of the external monitoring
+        """
+        Check the status of the external monitoring.
 
-        Returns:
-            str: external monitoring
+        Returns
+        -------
+        str
+            The status of the external monitoring.
         """
         response = requests.get(
             url=f"{self.external_monitoring_url}/{self.ex_monitoring_hash}/status",
@@ -329,11 +361,15 @@ class MLOpsExternalMonitoring(BaseMLOps):
         )
 
     def logs(self, start: str, end: str):
-        """Get the logs of an external monitoring
+        """
+        Get the logs of an external monitoring.
 
-        Args:
-            start (str): start date to look for the records. The format must be dd-MM-yyyy
-            end (str): end date to look for the records. The format must be dd-MM-yyyy
+        Parameters
+        ----------
+        start : str
+            Start date to look for the records. The format must be `dd-MM-yyyy`.
+        end : str
+            End date to look for the records. The format must be `dd-MM-yyyy`.
         """
         url = f"{self.base_url}/monitoring/search/records/{self.group}/{self.ex_monitoring_hash}"
         print(
@@ -435,27 +471,46 @@ class MLOpsExternalMonitoringClient(BaseMLOpsClient):
         raise ExternalMonitoringError("Could not register the monitoring.")
 
     def register_monitoring(self,**kwargs) -> Optional[MLOpsExternalMonitoring]:
-        """Register a MLOps External Monitoring
+        """
+        Register a MLOps External Monitoring.
 
-        Args:
-            name (str): External Monitoring name
-            group (str): External Monitoring group. The group is the same used for the external training and datasource
-            training_execution_id (int): Valid Mlops training execution id
-            period (str): The frequency the monitoring will run. It can be: "Day" | "Week" | "Quarter" | "Month" | "Year"
-            input_cols (list): List with input columns name
-            output_cols (list): List with output columns name
-            datasource_name (str): Valid Mlops datasource name
-            extraction_type (str): Type of extraction. It can be "Incremental" | "Full"
-            datasource_uri (str): Valid datasource Uri
-            column_name (str): Optional column name of the data column
-            reference_date (str): Optional reference extraction date
-            python_version (str): Optional python version used to run preprocessing scripts. It can be "3.8" | "3.9" | "3.10"
+        Parameters
+        ----------
+        name : str
+            External Monitoring name.
+        group : str
+            External Monitoring group. The group is the same used for the external training and datasource.
+        training_execution_id : int
+            Valid MLOps training execution id.
+        period : str
+            The frequency the monitoring will run. It can be one of the following: "Day", "Week", "Quarter",
+            "Month", "Year".
+        input_cols : list
+            List with input column names.
+        output_cols : list
+            List with output column names.
+        datasource_name : str
+            Valid MLOps datasource name.
+        extraction_type : str
+            Type of extraction. It can be one of the following: "Incremental", "Full".
+        datasource_uri : str
+            Valid datasource URI.
+        column_name : Optional[str], optional
+            Column name of the data column.
+        reference_date : Optional[str], optional
+            Reference extraction date.
+        python_version : Optional[str], optional
+            Python version used to run preprocessing scripts. It can be one of the following: "3.8", "3.9", "3.10". Defaults to "3.10".
 
-        Raises:
-            InputError
+        Raises
+        ------
+        InputError
+            Raised if there is an error with the provided input.
 
-        Returns:
-            MLOpsExternalMonitoring
+        Returns
+        -------
+        MLOpsExternalMonitoring
+            The newly registered MLOps external monitoring instance.
         """
 
         try:
@@ -568,16 +623,23 @@ class MLOpsExternalMonitoringClient(BaseMLOpsClient):
     def get_external_monitoring(
         self, external_monitoring_hash: str
     ) -> MLOpsExternalMonitoring:
-        """Return an external monitoring
+        """
+        Return an external monitoring.
 
-        Args:
-            external_monitoring_hash (str): External Monitoring Hash
+        Parameters
+        ----------
+        external_monitoring_hash : str
+            External Monitoring Hash.
 
-        Raises:
-            ExternalMonitoringError
+        Raises
+        ------
+        ExternalMonitoringError
+            Raised if there is an error fetching the external monitoring.
 
-        Returns:
-            MLOpsExternalMonitoring
+        Returns
+        -------
+        MLOpsExternalMonitoring
+            The requested MLOps external monitoring instance.
         """
 
         for external_monitoring_dict in self.__list_external_monitoring():

--- a/src/mlops_codex/external_monitoring.py
+++ b/src/mlops_codex/external_monitoring.py
@@ -382,8 +382,30 @@ class MLOpsExternalMonitoring(BaseMLOps):
 class MLOpsExternalMonitoringClient(BaseMLOpsClient):
     """
     Class that handles MLOps External Monitoring Client
+
+    Parameters
+    ----------
+    login : str
+        Login for authenticating with the client.
+        You can also use the env variable MLOPS_USER to set this
+    password : str
+        Password for authenticating with the client.
+        You can also use the env variable MLOPS_PASSWORD to set this
+    url : str
+        URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
+
+    Raises
+    ------
+    ServerError
+        Database produced an unexpected error.
+    AuthenticationError
+        If user is not in the master group.
+    CredentialError
+        If the Cloud Credential is Invalid
     """
 
+    # TODO: It would be more appropriate to move this to an internal creation method, as its current placement seems illogical.
+    #       btw, it is my mistake!!
     class ExternalMonitoringData(NamedTuple):
         """External monitoring data"""
         name: str

--- a/src/mlops_codex/logging.py
+++ b/src/mlops_codex/logging.py
@@ -10,7 +10,7 @@ class Logger:
 
     Attributes
     -----------
-    model_type : str
+    model_type: str
         Attribute that designates the type of the model being executed. Can be 'Sync' or 'Async'
 
     Raises
@@ -66,9 +66,9 @@ class Logger:
 
         Parameters
         -----------
-        level : str
+        level: str
             Log level (must be one used when initiating the logger)
-        message : str
+        message: str
             Message that will be logged
         """
 
@@ -99,7 +99,7 @@ class Logger:
 
         Parameters
         ----------
-        message : str
+        message: str
             Message that will be logged
         """
         self.__log("DEBUG", message)
@@ -110,7 +110,7 @@ class Logger:
 
         Parameters
         ----------
-        message : str
+        message: str
             Message that will be logged
         """
         self.__log("WARNING", message)
@@ -121,7 +121,7 @@ class Logger:
 
         Parameters
         ----------
-        message : str
+        message: str
             Message that will be logged
         """
         self.__log("ERROR", message)
@@ -148,7 +148,7 @@ class Logger:
 
         Parameters
         ----------
-        output : str
+        output: str
             Output of the function being executed.
         """
 

--- a/src/mlops_codex/model.py
+++ b/src/mlops_codex/model.py
@@ -46,11 +46,11 @@ class MLOpsModel(BaseMLOps):
     model_id : str
         Model id (hash) from the model you want to access
     group : str
-        Group the model is inserted. Default is 'datarisk' (public group)
+        Group the model is inserted.
     group_token : str
         Token for executing the model (show when creating a group). It can be informed when getting the model or when running predictions, or using the env variable MLOPS_GROUP_TOKEN
     url : str
-        URL to MLOps Server. Default value is https://mlops.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set these
+        URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set these
 
     Raises
     ------
@@ -87,11 +87,11 @@ class MLOpsModel(BaseMLOps):
         self,
         *,
         model_id: str,
+        group: str,
         login: Optional[str] = None,
         password: Optional[str] = None,
-        group: str = "datarisk",
         group_token: Optional[str] = None,
-        url: str = "https://neomaril.datarisk.net/",
+        url: Optional[str] = None,
     ) -> None:
         super().__init__(login=login, password=password, url=url)
 
@@ -283,7 +283,7 @@ class MLOpsModel(BaseMLOps):
         ServerError
             Raised if the server encounters an issue.
         ModelError
-            Raised if could not restart the model.
+            Raised if model could not be restarted.
 
         Example
         -------
@@ -382,8 +382,7 @@ class MLOpsModel(BaseMLOps):
 
     def delete(self):
         """
-        Deletes the current model.
-        IMPORTANT! For now this is irreversible, if you want to use the model again later you will need to upload again (and it will have a new ID).
+        Deletes the current model. IMPORTANT! For now this is irreversible, if you want to use the model again later you will need to upload again (and it will have a new ID).
 
         Raises
         ------
@@ -839,7 +838,7 @@ class MLOpsModel(BaseMLOps):
         Parameters
         ----------
         group : str
-            Group the model is inserted. Default is 'datarisk' (public group)
+            Group the model is inserted.
         model_id : str
             The uploaded model id (hash)
         period : str
@@ -897,7 +896,7 @@ class MLOpsModel(BaseMLOps):
         Parameters
         ----------
         group : str
-            Group the model is inserted. Default is 'datarisk' (public group)
+            Group the model is inserted.
         model_id : str
             The uploaded model id (hash)
         period : str
@@ -1459,7 +1458,7 @@ class MLOpsModelClient(BaseMLOpsClient):
         group: Optional[str] = None,
         extra_files: Optional[list] = None,
         env: Optional[str] = None,
-        python_version: str = "3.8",
+        python_version: str = "3.10",
         operation: str = "Sync",
         input_type: str = None,
     ) -> str:
@@ -1480,15 +1479,15 @@ class MLOpsModelClient(BaseMLOpsClient):
             Path of the requirements file. The packages versions must be fixed eg: pandas==1.0
         schema : Union[str, dict], optional
             Path to a JSON or XML file with a sample of the input for the entrypoint function. A dict with the sample input can be sending as well
-        group : str, optional
-            Group the model is inserted. If None the server uses 'datarisk' (public group)
-        extra_files : list, optional
+        group : Optional[str], optional
+            Group the model is inserted.
+        extra_files : Optional[list], optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file
         env : str, optional
             Flag that choose which environment (dev, staging, production) of MLOps you are using. Default is True
-        python_version : str, optional
-            Python version for the model environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.8'
-        operation : str
+        python_version : Optional[str], optional
+            Python version for the model environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.10'
+        operation : Optional[str], optional
             Defines which kind operation is being executed (Sync or Async). Default value is Sync
         input_type : str
             The type of the input file that should be 'json', 'csv', 'parquet', 'txt', 'xls', 'xlsx'
@@ -1640,7 +1639,7 @@ class MLOpsModelClient(BaseMLOpsClient):
         schema: Optional[Union[str, dict]] = None,
         extra_files: Optional[list] = None,
         env: Optional[str] = None,
-        python_version: str = "3.8",
+        python_version: str = "3.10",
         operation="Sync",
         input_type: str = "json|csv|parquet",
         wait_for_ready: bool = True,
@@ -1667,15 +1666,15 @@ class MLOpsModelClient(BaseMLOpsClient):
         extra_files : list, optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file
         env : str, optional
-            .env file to be used in your model enviroment. This will be encrypted in the server.
+            .env file to be used in your model environment. This will be encrypted in the server.
         python_version : str, optional
-            Python version for the model environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.8'
+            Python version for the model environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.10'
         operation : str
-            Defines wich kind operation is beeing executed (Sync or Async). Default value is Sync
+            Defines which kind operation is being executed (Sync or Async). Default value is Sync
         input_type : str
             The type of the input file that should be 'json', 'csv' or 'parquet'
         wait_for_ready : bool, optional
-            Wait for model to be ready and returns a MLOpsModel instace with the new model. Defaults to True
+            Wait for model to be ready and returns a MLOpsModel instance with the new model. Defaults to True
 
         Raises
         ------

--- a/src/mlops_codex/model.py
+++ b/src/mlops_codex/model.py
@@ -39,17 +39,17 @@ class MLOpsModel(BaseMLOps):
 
     Parameters
     ----------
-    login : str
+    login: str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
-    model_id : str
+    model_id: str
         Model id (hash) from the model you want to access
-    group : str
+    group: str
         Group the model is inserted.
-    group_token : str
+    group_token: str
         Token for executing the model (show when creating a group). It can be informed when getting the model or when running predictions, or using the env variable MLOPS_GROUP_TOKEN
-    url : str
+    url: str
         URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set these
 
     Raises
@@ -273,7 +273,7 @@ class MLOpsModel(BaseMLOps):
 
         Parameters
         -----------
-        wait_for_ready : bool
+        wait_for_ready: bool
             If the model is being deployed, wait for it to be ready instead of failing the request. Defaults to True
 
         Raises
@@ -340,13 +340,13 @@ class MLOpsModel(BaseMLOps):
 
         Parameters
         -----------
-        start : str, optional
+        start: Optional[str], optional
             Date to start filter. At the format aaaa-mm-dd
-        end : str, optional
+        end: Optional[str], optional
             Date to end filter. At the format aaaa-mm-dd
-        routine : str, optional
+        routine: Optional[str], optional
             Type of routine beeing executed, can assume values Host or Run
-        type : str, optional
+        type: Optional[str], optional
             Defines the type of the logs that are going to be filtered, can assume the values Ok, Error, Debug or Warning
 
         Raises
@@ -508,7 +508,7 @@ class MLOpsModel(BaseMLOps):
 
         Parameters
         ----------
-        group_token : str
+        group_token: str
             Token for executing the model (show when creating a group). You can set this using the MLOPS_GROUP_TOKEN env variable
 
         Example
@@ -533,13 +533,13 @@ class MLOpsModel(BaseMLOps):
 
         Parameters
         ----------
-        data : Union[dict, str]
+        data: Union[dict, str]
             The same data that is used in the source file.
             If Sync is a dict, the keys that are needed inside this dict are the ones in the `schema` attribute.
             If Async is a string with the file path with the same filename used in the source file.
-        group_token : str, optional
+        group_token: Optional[str], optional
             Token for executing the model (show when creating a group). It can be informed when getting the model or when running predictions, or using the env variable MLOPS_GROUP_TOKEN
-        wait_complete: bool, optional
+        wait_complete: Optional[bool], optional
             Boolean that informs if a model training is completed (True) or not (False). Default value is False
 
         Raises
@@ -689,7 +689,7 @@ class MLOpsModel(BaseMLOps):
 
         Parameters
         ----------
-        language : str
+        language: str
             The generated code language. Supported languages are 'curl', 'python' or 'javascript'
 
         Raises
@@ -803,7 +803,7 @@ class MLOpsModel(BaseMLOps):
 
         Parameters
         ----------
-        exec_id : str
+        exec_id: str
             Execution id
 
         Raises
@@ -837,11 +837,11 @@ class MLOpsModel(BaseMLOps):
 
         Parameters
         ----------
-        group : str
+        group: str
             Group the model is inserted.
-        model_id : str
+        model_id: str
             The uploaded model id (hash)
-        period : str
+        period: str
             The monitoring period (Day, Week, Month)
 
         Raises
@@ -895,11 +895,11 @@ class MLOpsModel(BaseMLOps):
 
         Parameters
         ----------
-        group : str
+        group: str
             Group the model is inserted.
-        model_id : str
+        model_id: str
             The uploaded model id (hash)
-        period : str
+        period: str
             The monitoring period (Day, Week, Month)
 
         Raises
@@ -950,15 +950,15 @@ class MLOpsModel(BaseMLOps):
 
         Parameters
         ----------
-        preprocess_reference : str
+        preprocess_reference: str
             Name of the preprocess reference
-        shap_reference : str
+        shap_reference: str
             Name of the preprocess function
-        configuration_file : str or dict
+        configuration_file: str or dict
             Path of the configuration file, but it could be a dict
-        preprocess_file : str, optional
+        preprocess_file: Optional[str], optional
             Path of the preprocess script
-        requirements_file : str
+        requirements_file: str
             Path of the requirements file
 
         Raises
@@ -1063,11 +1063,11 @@ class MLOpsModelClient(BaseMLOpsClient):
 
     Parameters
     ----------
-    login : str
+    login: str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
-    url : str
+    url: str
         URL to MLOps Server. Default value is https://neomaril.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
@@ -1179,9 +1179,9 @@ class MLOpsModelClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        group : str
+        group: str
             Group the model is inserted
-        model_id : str
+        model_id: str
             Model id (hash) from the model being searched
 
         Raises
@@ -1360,7 +1360,7 @@ class MLOpsModelClient(BaseMLOpsClient):
             results = response.json()["Results"]
             parsed_results = []
             for r in results:
-                if schema := r.get("Schema"):
+                if schema:= r.get("Schema"):
                     r["Schema"] = json.loads(schema)
                 parsed_results.append(r)
 
@@ -1404,15 +1404,15 @@ class MLOpsModelClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        model_id : str
+        model_id: str
             Model id (hash)
-        start : str, optional
+        start: str, optional
             Date to start filter. At the format aaaa-mm-dd
-        end : str, optional
+        end: str, optional
             Date to end filter. At the format aaaa-mm-dd
-        routine : str, optional
+        routine: str, optional
             Type of routine being executed, can assume values 'Host' (for deployment logs) or 'Run' (for execution logs)
-        type : str, optional
+        type: str, optional
             Defines the type of the logs that are going to be filtered, can assume the values 'Ok', 'Error', 'Debug' or 'Warning'
 
         Raises
@@ -1467,29 +1467,29 @@ class MLOpsModelClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        model_name : str
+        model_name: str
             The name of the model, in less than 32 characters
-        model_reference : str
+        model_reference: str
             The name of the scoring function inside the source file
-        source_file : str
+        source_file: str
             Path of the source file. The file must have a scoring function that accepts two parameters: data (data for the request body of the model) and model_path (absolute path of where the file is located)
-        model_file : str
+        model_file: str
             Path of the model pkl file
-        requirements_file : str
+        requirements_file: str
             Path of the requirements file. The packages versions must be fixed eg: pandas==1.0
-        schema : Union[str, dict], optional
+        schema: Union[str, dict], optional
             Path to a JSON or XML file with a sample of the input for the entrypoint function. A dict with the sample input can be sending as well
-        group : Optional[str], optional
+        group: Optional[str], optional
             Group the model is inserted.
-        extra_files : Optional[list], optional
+        extra_files: Optional[list], optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file
-        env : str, optional
+        env: str, optional
             Flag that choose which environment (dev, staging, production) of MLOps you are using. Default is True
-        python_version : Optional[str], optional
+        python_version: Optional[str], optional
             Python version for the model environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.10'
-        operation : Optional[str], optional
+        operation: Optional[str], optional
             Defines which kind operation is being executed (Sync or Async). Default value is Sync
-        input_type : str
+        input_type: str
             The type of the input file that should be 'json', 'csv', 'parquet', 'txt', 'xls', 'xlsx'
 
         Raises
@@ -1584,11 +1584,11 @@ class MLOpsModelClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        operation : str
+        operation: str
             The model operation type (Sync or Async)
-        model_id : str
+        model_id: str
             The uploaded model id (hash)
-        group : str
+        group: str
             Group the model is inserted. Default is 'datarisk' (public group)
 
         Raises
@@ -1649,31 +1649,31 @@ class MLOpsModelClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        model_name : str
+        model_name: str
             The name of the model, in less than 32 characters
-        model_reference : str
+        model_reference: str
             The name of the scoring function inside the source file
-        source_file : str
+        source_file: str
             Path of the source file. The file must have a scoring function that accepts two parameters: data (data for the request body of the model) and model_path (absolute path of where the file is located)
-        model_file : str
+        model_file: str
             Path of the model pkl file
-        requirements_file : str
+        requirements_file: str
             Path of the requirements file. The packages versions must be fixed eg: pandas==1.0
-        schema : Union[str, dict]
+        schema: Union[str, dict]
             Path to a JSON or XML file with a sample of the input for the entrypoint function. A dict with the sample input can be sending as well. Mandatory for Sync models
-        group : str
+        group: str
             Group the model is inserted.
-        extra_files : list, optional
+        extra_files: list, optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file
-        env : str, optional
+        env: str, optional
             .env file to be used in your model environment. This will be encrypted in the server.
-        python_version : str, optional
+        python_version: str, optional
             Python version for the model environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.10'
-        operation : str
+        operation: str
             Defines which kind operation is being executed (Sync or Async). Default value is Sync
-        input_type : str
+        input_type: str
             The type of the input file that should be 'json', 'csv' or 'parquet'
-        wait_for_ready : bool, optional
+        wait_for_ready: bool, optional
             Wait for model to be ready and returns a MLOpsModel instance with the new model. Defaults to True
 
         Raises
@@ -1723,11 +1723,11 @@ class MLOpsModelClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        model_id : str
+        model_id: str
             Model id (hash)
-        exec_id : str
+        exec_id: str
             Execution id
-        group : str, optional
+        group: str, optional
             Group name, default value is None
 
         Returns

--- a/src/mlops_codex/model.py
+++ b/src/mlops_codex/model.py
@@ -37,7 +37,7 @@ class MLOpsModel(BaseMLOps):
     """
     Class to manage Models deployed inside MLOps
 
-    Attributes
+    Parameters
     ----------
     login : str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
@@ -50,16 +50,14 @@ class MLOpsModel(BaseMLOps):
     group_token : str
         Token for executing the model (show when creating a group). It can be informed when getting the model or when running predictions, or using the env variable MLOPS_GROUP_TOKEN
     url : str
-        URL to MLOps Server. Default value is https://neomaril.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set these
-    docs : str
-        URL for the model Swagger page
+        URL to MLOps Server. Default value is https://mlops.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set these
 
     Raises
     ------
     ModelError
         When the model can't be accessed in the server
     AuthenticationError
-        Unvalid credentials
+        Invalid credentials
 
     Example
     --------
@@ -207,6 +205,15 @@ class MLOpsModel(BaseMLOps):
         """
         Get the model deployment process health state.
 
+        Raises
+        ------
+        AuthenticationError
+            Raised if there is an authentication issue.
+        ServerError
+            Raised if the server encounters an issue.
+        ModelError
+            Raised if it can not get the health of the model
+
         Returns
         -------
         str
@@ -268,6 +275,15 @@ class MLOpsModel(BaseMLOps):
         -----------
         wait_for_ready : bool
             If the model is being deployed, wait for it to be ready instead of failing the request. Defaults to True
+
+        Raises
+        ------
+        AuthenticationError
+            Raised if there is an authentication issue.
+        ServerError
+            Raised if the server encounters an issue.
+        ModelError
+            Raised if could not restart the model.
 
         Example
         -------
@@ -340,7 +356,7 @@ class MLOpsModel(BaseMLOps):
 
         Returns
         -------
-        json
+        dict
             Logs list
 
         Example
@@ -371,6 +387,8 @@ class MLOpsModel(BaseMLOps):
 
         Raises
         ------
+        AuthenticationError
+            Raised if there is an authentication issue.
         ServerError
             Model deleting failed
 
@@ -429,12 +447,14 @@ class MLOpsModel(BaseMLOps):
 
         Raises
         ------
+        AuthenticationError
+            Raised if there is an authentication issue.
         ServerError
-            Model deleting failed
+            Model disable failed
 
         Returns
         -------
-        str
+        dict
             status=Deployed: disables the model and return a json.
             If it isn't Deployed it returns the message that the model is under another state
 
@@ -487,8 +507,8 @@ class MLOpsModel(BaseMLOps):
         """
         Saves the group token for this model instance.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         group_token : str
             Token for executing the model (show when creating a group). You can set this using the MLOPS_GROUP_TOKEN env variable
 
@@ -512,8 +532,8 @@ class MLOpsModel(BaseMLOps):
         """
         Runs a prediction from the current model.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         data : Union[dict, str]
             The same data that is used in the source file.
             If Sync is a dict, the keys that are needed inside this dict are the ones in the `schema` attribute.
@@ -668,8 +688,8 @@ class MLOpsModel(BaseMLOps):
         """
         Generates predict code for the model to be used outside MLOps Codex
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         language : str
             The generated code language. Supported languages are 'curl', 'python' or 'javascript'
 
@@ -780,10 +800,10 @@ class MLOpsModel(BaseMLOps):
 
     def get_model_execution(self, exec_id: str) -> MLOpsExecution:
         """
-        Get a execution instace for that model.
+        Get an execution instace for that model.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         exec_id : str
             Execution id
 
@@ -816,8 +836,8 @@ class MLOpsModel(BaseMLOps):
         """
         Get the host status for the monitoring configuration
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         group : str
             Group the model is inserted. Default is 'datarisk' (public group)
         model_id : str
@@ -874,8 +894,8 @@ class MLOpsModel(BaseMLOps):
         """
         Host the monitoring configuration
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         group : str
             Group the model is inserted. Default is 'datarisk' (public group)
         model_id : str
@@ -929,8 +949,8 @@ class MLOpsModel(BaseMLOps):
         """
         Register the model monitoring configuration at the database
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         preprocess_reference : str
             Name of the preprocess reference
         shap_reference : str
@@ -941,7 +961,6 @@ class MLOpsModel(BaseMLOps):
             Path of the preprocess script
         requirements_file : str
             Path of the requirements file
-
 
         Raises
         ------
@@ -1043,7 +1062,7 @@ class MLOpsModelClient(BaseMLOpsClient):
     """
     Class for client to access MLOps and manage models
 
-    Attributes
+    Parameters
     ----------
     login : str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
@@ -1194,22 +1213,22 @@ class MLOpsModelClient(BaseMLOpsClient):
         self,
         *,
         model_id: str,
-        group: str = "datarisk",
+        group: str,
         group_token: Optional[str] = None,
-        wait_for_ready: bool = True,
+        wait_for_ready: Optional[bool] = True,
     ) -> MLOpsModel:
         """
         Acess a model using its id
 
-        Arguments
-        ---------
-        model_id : str
+        Parameters
+        ----------
+        model_id: str
             Model id (hash) that needs to be acessed
-        group : str
-            Group the model is inserted. Default is 'datarisk' (public group)
-        group_token : str, optional
+        group: str
+            Group the model is inserted.
+        group_token: Optional[str], optional
             Token for executing the model (show when creating a group). It can be informed when getting the model or when running predictions, or using the env variable MLOPS_GROUP_TOKEN
-        wait_for_ready : bool
+        wait_for_ready: Optional[bool], optional
             If the model is being deployed, wait for it to be ready instead of failing the request. Defaults to True
 
         Raises
@@ -1287,15 +1306,15 @@ class MLOpsModelClient(BaseMLOpsClient):
         """
         Search for models using the name of the model
 
-        Arguments
-        ---------
-        name : str, optional
+        Parameters
+        ----------
+        name: Optional[str], optional
             Text that it's expected to be on the model name. It runs similar to a LIKE query on SQL
-        state : str, optional
+        state: Optional[str], optional
             Text that it's expected to be on the state. It runs similar to a LIKE query on SQL
-        group : str, optional
+        group: Optional[str], optional
             Text that it's expected to be on the group name. It runs similar to a LIKE query on SQL
-        only_deployed : bool, optional
+        only_deployed: Optional[bool], optional
             If it's True, filter only models ready to be used (status == "Deployed"). Defaults to False
 
         Raises
@@ -1306,7 +1325,7 @@ class MLOpsModelClient(BaseMLOpsClient):
         Returns
         -------
         list
-            List with the models data, it can works like a filter depending on the arguments values
+            A list with the models data, it can works like a filter depending on the arguments values
         Example
         -------
         >>> client.search_models(group='ex_group', only_deployed=True)
@@ -1404,7 +1423,7 @@ class MLOpsModelClient(BaseMLOpsClient):
 
         Returns
         -------
-        json
+        dict
             Logs list
 
         Example
@@ -1447,8 +1466,8 @@ class MLOpsModelClient(BaseMLOpsClient):
         """
         Upload the files to the server
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         model_name : str
             The name of the model, in less than 32 characters
         model_reference : str
@@ -1564,8 +1583,8 @@ class MLOpsModelClient(BaseMLOpsClient):
         """
         Builds the model execution environment
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         operation : str
             The model operation type (Sync or Async)
         model_id : str
@@ -1629,8 +1648,8 @@ class MLOpsModelClient(BaseMLOpsClient):
         """
         Deploy a new model to MLOps.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         model_name : str
             The name of the model, in less than 32 characters
         model_reference : str
@@ -1701,10 +1720,10 @@ class MLOpsModelClient(BaseMLOpsClient):
         self, *, model_id: str, exec_id: str, group: Optional[str] = None
     ) -> MLOpsExecution:
         """
-        Get a execution instace (Async model only).
+        Get an execution instace (Async model only).
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         model_id : str
             Model id (hash)
         exec_id : str

--- a/src/mlops_codex/pipeline.py
+++ b/src/mlops_codex/pipeline.py
@@ -21,15 +21,15 @@ class MLOpsPipeline(BaseMLOps):
 
     Parameters
     ----------
-    login : str
+    login: str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
-    group : str
+    group: str
         Group the model is inserted
-    url : str
+    url: str
         URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
-    python_version : str
+    python_version: str
         Python version for the model environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.9'
 
     Example
@@ -80,7 +80,7 @@ class MLOpsPipeline(BaseMLOps):
 
         Parameters
         ----------
-        kwargs : list or dict
+        kwargs: list or dict
             List or dictionary with the necessary files for training
         """
         self.train_config = kwargs
@@ -91,7 +91,7 @@ class MLOpsPipeline(BaseMLOps):
 
         Parameters
         ----------
-        kwargs : list or dict
+        kwargs: list or dict
             List or dictionary with the necessary files for deploy
         """
         self.deploy_config = kwargs
@@ -102,7 +102,7 @@ class MLOpsPipeline(BaseMLOps):
 
         Parameters
         ----------
-        kwargs : list or dict
+        kwargs: list or dict
             List or dictionary with the necessary files for monitoring
 
         Example
@@ -118,7 +118,7 @@ class MLOpsPipeline(BaseMLOps):
 
         Parameters
         ----------
-        path : str
+        path: str
             Path of the configuration file, but it could be a dict
 
         Raises
@@ -279,7 +279,7 @@ class MLOpsPipeline(BaseMLOps):
 
         Parameters
         ----------
-        training_id : Optional[str], optional
+        training_id: Optional[str], optional
             The id for the training process that you want to deploy now
 
         Raises
@@ -376,9 +376,9 @@ class MLOpsPipeline(BaseMLOps):
 
         Parameters
         ----------
-        training_exec_id : Optional[str], optional
+        training_exec_id: Optional[str], optional
             The id for the training execution process that you want to monitore now
-        model_id : Optional[str], optional
+        model_id: Optional[str], optional
             Model hash
 
         Example

--- a/src/mlops_codex/pipeline.py
+++ b/src/mlops_codex/pipeline.py
@@ -19,7 +19,7 @@ class MLOpsPipeline(BaseMLOps):
     """
     Class to construct and orchestrates the flow data of the models inside MLOps.
 
-    Attributes
+    Parameters
     ----------
     login : str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
@@ -28,7 +28,7 @@ class MLOpsPipeline(BaseMLOps):
     group : str
         Group the model is inserted
     url : str
-        URL to MLOps Server. Default value is https://neomaril.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
+        URL to MLOps Server. Default value is https://mlops.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
     python_version : str
         Python version for the model environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.9'
 
@@ -277,9 +277,9 @@ class MLOpsPipeline(BaseMLOps):
         """
         Run the deployment process
 
-        Arguments
+        Parameters
         ----------
-        training_id : str, optional
+        training_id : Optional[str], optional
             The id for the training process that you want to deploy now
 
         Raises
@@ -374,11 +374,12 @@ class MLOpsPipeline(BaseMLOps):
         """
         Run the monitoring process
 
-        Arguments
+        Parameters
         ----------
-        training_exec_id : str, optional
+        training_exec_id : Optional[str], optional
             The id for the training execution process that you want to monitore now
-        model_id : str, optional
+        model_id : Optional[str], optional
+            Model hash
 
         Example
         -------

--- a/src/mlops_codex/pipeline.py
+++ b/src/mlops_codex/pipeline.py
@@ -28,7 +28,7 @@ class MLOpsPipeline(BaseMLOps):
     group : str
         Group the model is inserted
     url : str
-        URL to MLOps Server. Default value is https://mlops.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
+        URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
     python_version : str
         Python version for the model environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.9'
 
@@ -51,7 +51,7 @@ class MLOpsPipeline(BaseMLOps):
         group: str,
         login: Optional[str] = None,
         password: Optional[str] = None,
-        url: str = "https://neomaril.datarisk.net/",
+        url: Optional[str] = None,
         python_version: float = 3.9,
     ) -> None:
         super().__init__(login=login, password=password, url=url)

--- a/src/mlops_codex/preprocessing.py
+++ b/src/mlops_codex/preprocessing.py
@@ -41,7 +41,7 @@ class MLOpsPreprocessing(BaseMLOps):
     group : str
         Group the model is inserted.
     base_url : str
-        URL to MLOps Server. Default value is https://mlops.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
+        URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Example
     --------
@@ -66,9 +66,9 @@ class MLOpsPreprocessing(BaseMLOps):
         preprocessing_id: str,
         login: Optional[str] = None,
         password: Optional[str] = None,
-        group: str = "datarisk",
+        group: Optional[str] = None,
         group_token: Optional[str] = None,
-        url: str = "https://neomaril.datarisk.net/",
+        url: Optional[str] = None,
     ) -> None:
         super().__init__(login=login, password=password, url=url)
         self.preprocessing_id = preprocessing_id
@@ -373,7 +373,7 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
     password : str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
     url : str
-        URL to MLOps Server. Default value is https://mlops.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
+        URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
     ------
@@ -758,7 +758,7 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         group: Optional[str],
         extra_files: Optional[list] = None,
         env: Optional[str] = None,
-        python_version: str = "3.8",
+        python_version: str = "3.10",
         operation: str = "Sync",
         input_type: str = None,
     ) -> str:
@@ -784,7 +784,7 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         env : str, optional
             Flag that choose which environment (dev, staging, production) of MLOps you are using. Default is True
         python_version : str, optional
-            Python version for the preprocessing environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.8'
+            Python version for the preprocessing environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.10'
         operation : str
             Defines which kind operation is being executed (Sync or Async). Default value is Sync
         input_type : str
@@ -940,7 +940,7 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         schema: Optional[Union[str, dict]] = None,
         extra_files: Optional[list] = None,
         env: Optional[str] = None,
-        python_version: str = "3.8",
+        python_version: str = "3.10",
         operation="Sync",
         input_type: str = "json|csv|parquet",
         wait_for_ready: bool = True,
@@ -967,7 +967,7 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         env : Optional[str], optional
             Flag that choose which environment (dev, staging, production) of MLOps you are using. Default is True
         python_version : Optional[str], optional
-            Python version for the preprocessing environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.8'
+            Python version for the preprocessing environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.10'
         operation : str
             Defines wich kind operation is beeing executed (Sync or Async). Default value is Sync
         input_type : str

--- a/src/mlops_codex/preprocessing.py
+++ b/src/mlops_codex/preprocessing.py
@@ -32,15 +32,15 @@ class MLOpsPreprocessing(BaseMLOps):
 
     Parameters
     ----------
-    login : str
+    login: str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
-    preprocessing_id : str
+    preprocessing_id: str
         Preprocessing script id (hash) from the script you want to access
-    group : str
+    group: str
         Group the model is inserted.
-    base_url : str
+    base_url: str
         URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Example
@@ -129,13 +129,13 @@ class MLOpsPreprocessing(BaseMLOps):
 
         Parameters
         -----------
-        start : Optional[str], optional
+        start: Optional[str], optional
             Date to start filter. At the format aaaa-mm-dd
-        end : Optional[str], optional
+        end: Optional[str], optional
             Date to end filter. At the format aaaa-mm-dd
-        routine : Optional[str], optional
+        routine: Optional[str], optional
             Type of routine beeing executed, can assume values Host or Run
-        type : Optional[str], optional
+        type: Optional[str], optional
             Defines the type of the logs that are going to be filtered, can assume the values Ok, Error, Debug or Warning
 
         Raises
@@ -175,7 +175,7 @@ class MLOpsPreprocessing(BaseMLOps):
 
         Parameters
         ----------
-        group_token : str
+        group_token: str
             Token for executing the preprocessing (show when creating a group). You can set this using the MLOPS_GROUP_TOKEN env variable
 
         Example
@@ -198,13 +198,13 @@ class MLOpsPreprocessing(BaseMLOps):
 
         Parameters
         ----------
-        data : Union[dict, str]
+        data: Union[dict, str]
             The same data that is used in the source file.
             If Sync is a dict, the keys that are needed inside this dict are the ones in the `schema` attribute.
             If Async is a string with the file path with the same filename used in the source file.
-        group_token : str, optional
+        group_token: Optional[str], optional
             Token for executing the preprocessing (show when creating a group). It can be informed when getting the preprocessing or when running predictions, or using the env variable MLOPS_GROUP_TOKEN
-        wait_complete: bool, optional
+        wait_complete: Optional[bool], optional
             Boolean that informs if a preprocessing training is completed (True) or not (False). Default value is False
 
         Raises
@@ -368,11 +368,11 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
 
     Parameters
     ----------
-    login : str
+    login: str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
-    url : str
+    url: str
         URL to MLOps Server. Default value is https://neomaril.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
@@ -408,7 +408,7 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
 
         sync_preprocessing.set_token('TOKEN')
 
-        result = sync_preprocessing.run({'variable' : 100})
+        result = sync_preprocessing.run({'variable': 100})
         result
 
     Example 2: creation and deployment of an Asynchronous Preprocess script
@@ -485,9 +485,9 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        group : str
+        group: str
             Group the preprocessing is inserted
-        preprocessing_id : str
+        preprocessing_id: str
             Pre processing id (hash) from the preprocessing being searched
 
         Raises
@@ -531,13 +531,13 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        preprocessing_id : str
+        preprocessing_id: str
             Pre processing id (hash) that needs to be accessed.
-        group : str
+        group: str
             Group the preprocessing is inserted.
-        group_token : Optional[str], optional
+        group_token: Optional[str], optional
             Token for executing the preprocessing (show when creating a group). It can be informed when getting the preprocessing or when running predictions, or using the env variable MLOPS_GROUP_TOKEN
-        wait_for_ready : Optional[bool], optional
+        wait_for_ready: Optional[bool], optional
             If the preprocessing is being deployed, wait for it to be ready instead of failing the request. Defaults to True.
 
         Raises
@@ -623,13 +623,13 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        name : Optional[str], optional
+        name: Optional[str], optional
             Text that it's expected to be on the preprocessing name. It runs similar to a LIKE query on SQL
-        state : Optional[str], optional
+        state: Optional[str], optional
             Text that it's expected to be on the state. It runs similar to a LIKE query on SQL
-        group : Optional[str], optional
+        group: Optional[str], optional
             Text that it's expected to be on the group name. It runs similar to a LIKE query on SQL
-        only_deployed : Optional[bool], optional
+        only_deployed: Optional[bool], optional
             If it's True, filter only preprocessing ready to be used (status == "Deployed"). Defaults to False
 
         Raises
@@ -705,15 +705,15 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        preprocessing_id : str
+        preprocessing_id: str
             Pre processing id (hash)
-        start : str, optional
+        start: Optional[str], optional
             Date to start filter. At the format aaaa-mm-dd
-        end : Optional[str], optional
+        end: Optional[str], optional
             Date to end filter. At the format aaaa-mm-dd
-        routine : Optional[str], optional
+        routine: Optional[str], optional
             Type of routine being executed, can assume values 'Host' (for deployment logs) or 'Run' (for execution logs)
-        type : Optional[str], optional
+        type: Optional[str], optional
             Defines the type of the logs that are going to be filtered, can assume the values 'Ok', 'Error', 'Debug' or 'Warning'
 
         Raises
@@ -767,27 +767,27 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        preprocessing_name : str
+        preprocessing_name: str
             The name of the preprocessing, in less than 32 characters
-        preprocessing_reference : str
+        preprocessing_reference: str
             The name of the scoring function inside the source file
-        source_file : str
+        source_file: str
             Path of the source file. The file must have a scoring function that accepts two parameters: data (data for the request body of the preprocessing) and preprocessing_path (absolute path of where the file is located)
-        requirements_file : str
+        requirements_file: str
             Path of the requirements file. The packages versions must be fixed eg: pandas==1.0
-        schema : Union[str, dict], optional
+        schema: Union[str, dict], optional
             Path to a JSON or XML file with a sample of the input for the entrypoint function. A dict with the sample input can be sending as well
-        group : str, optional
+        group: str, optional
             Group the preprocessing is inserted. If None the server uses 'datarisk' (public group)
-        extra_files : list, optional
+        extra_files: list, optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file
-        env : str, optional
+        env: str, optional
             Flag that choose which environment (dev, staging, production) of MLOps you are using. Default is True
-        python_version : str, optional
+        python_version: str, optional
             Python version for the preprocessing environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.10'
-        operation : str
+        operation: str
             Defines which kind operation is being executed (Sync or Async). Default value is Sync
-        input_type : str
+        input_type: str
             The type of the input file that should be 'json', 'csv' or 'parquet'
 
         Raises
@@ -883,11 +883,11 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        operation : str
+        operation: str
             The preprocessing operation type (Sync or Async)
-        preprocessing_id : str
+        preprocessing_id: str
             The uploaded preprocessing id (hash)
-        group : str
+        group: str
             Group the preprocessing is inserted. Default is 'datarisk' (public group)
 
         Raises
@@ -950,29 +950,29 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        preprocessing_name : str
+        preprocessing_name: str
             The name of the preprocessing, in less than 32 characters
-        preprocessing_reference : str
+        preprocessing_reference: str
             The name of the scoring function inside the source file
-        source_file : str
+        source_file: str
             Path of the source file. The file must have a scoring function that accepts two parameters: data (data for the request body of the preprocessing) and preprocessing_path (absolute path of where the file is located)
-        requirements_file : str
+        requirements_file: str
             Path of the requirements file. The packages versions must be fixed eg: pandas==1.0
-        group : str
+        group: str
             Group the preprocessing is inserted.
-        schema : Optional[Union[str, dict]]
+        schema: Optional[Union[str, dict]]
             Path to a JSON or XML file with a sample of the input for the entrypoint function. A dict with the sample input can be sending as well. Mandatory for Sync preprocessing
-        extra_files : Optional[list], optional
+        extra_files: Optional[list], optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file
-        env : Optional[str], optional
+        env: Optional[str], optional
             Flag that choose which environment (dev, staging, production) of MLOps you are using. Default is True
-        python_version : Optional[str], optional
+        python_version: Optional[str], optional
             Python version for the preprocessing environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.10'
-        operation : str
+        operation: str
             Defines wich kind operation is beeing executed (Sync or Async). Default value is Sync
-        input_type : str
+        input_type: str
             The type of the input file that should be 'json', 'csv' or 'parquet'
-        wait_for_ready : Optional[bool], optional
+        wait_for_ready: Optional[bool], optional
             Wait for preprocessing to be ready and returns a MLOpsPreprocessing instace with the new preprocessing. Defaults to True
 
         Raises
@@ -1025,11 +1025,11 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
 
         Parameters
         ----------
-        preprocessing_id : str
+        preprocessing_id: str
             Pre processing id (hash)
-        exec_id : str
+        exec_id: str
             Execution id
-        group : str, optional
+        group: str, optional
             Group name, default value is None
 
         Returns

--- a/src/mlops_codex/preprocessing.py
+++ b/src/mlops_codex/preprocessing.py
@@ -30,7 +30,7 @@ class MLOpsPreprocessing(BaseMLOps):
     """
     Class to manage Preprocessing scripts deployed inside MLOps
 
-    Attributes
+    Parameters
     ----------
     login : str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
@@ -39,9 +39,9 @@ class MLOpsPreprocessing(BaseMLOps):
     preprocessing_id : str
         Preprocessing script id (hash) from the script you want to access
     group : str
-        Group the model is inserted. Default is 'datarisk' (public group)
+        Group the model is inserted.
     base_url : str
-        URL to MLOps Server. Default value is https://neomaril.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
+        URL to MLOps Server. Default value is https://mlops.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Example
     --------
@@ -104,7 +104,7 @@ class MLOpsPreprocessing(BaseMLOps):
 
     def wait_ready(self):
         """
-        Waits the pre processing to be with status 'Deployed'
+        Waits the pre-processing to be with status 'Deployed'
 
         Example
         -------
@@ -129,13 +129,13 @@ class MLOpsPreprocessing(BaseMLOps):
 
         Parameters
         -----------
-        start : str, optional
+        start : Optional[str], optional
             Date to start filter. At the format aaaa-mm-dd
-        end : str, optional
+        end : Optional[str], optional
             Date to end filter. At the format aaaa-mm-dd
-        routine : str, optional
+        routine : Optional[str], optional
             Type of routine beeing executed, can assume values Host or Run
-        type : str, optional
+        type : Optional[str], optional
             Defines the type of the logs that are going to be filtered, can assume the values Ok, Error, Debug or Warning
 
         Raises
@@ -145,7 +145,7 @@ class MLOpsPreprocessing(BaseMLOps):
 
         Returns
         -------
-        json
+        dict
             Logs list
 
         Example
@@ -173,8 +173,8 @@ class MLOpsPreprocessing(BaseMLOps):
         """
         Saves the group token for this preprocessing instance.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         group_token : str
             Token for executing the preprocessing (show when creating a group). You can set this using the MLOPS_GROUP_TOKEN env variable
 
@@ -196,8 +196,8 @@ class MLOpsPreprocessing(BaseMLOps):
         """
         Runs a prediction from the current preprocessing.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         data : Union[dict, str]
             The same data that is used in the source file.
             If Sync is a dict, the keys that are needed inside this dict are the ones in the `schema` attribute.
@@ -297,8 +297,8 @@ class MLOpsPreprocessing(BaseMLOps):
         """
         Get an execution instance for that preprocessing.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         exec_id: str
             Execution id
 
@@ -306,6 +306,11 @@ class MLOpsPreprocessing(BaseMLOps):
         ------
         PreprocessingError
             If the user tries to get an execution from a Sync preprocessing
+
+        Returns
+        -------
+        MlopsExecution
+            An execution instance for the preprocessing.
 
         Example
         -------
@@ -361,14 +366,14 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
     """
     Class for client to access MLOps and manage Preprocessing scripts
 
-    Attributes
+    Parameters
     ----------
     login : str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
     password : str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
     url : str
-        URL to MLOps Server. Default value is https://neomaril.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
+        URL to MLOps Server. Default value is https://mlops.datarisk.net/, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
     ------
@@ -517,23 +522,23 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         self,
         *,
         preprocessing_id: str,
-        group: str = "datarisk",
+        group: str,
         group_token: Optional[str] = None,
-        wait_for_ready: bool = True,
+        wait_for_ready: Optional[bool] = True,
     ) -> MLOpsPreprocessing:
         """
         Access a preprocessing using its id
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         preprocessing_id : str
-            Pre processing id (hash) that needs to be accessed
+            Pre processing id (hash) that needs to be accessed.
         group : str
-            Group the preprocessing is inserted. Default is 'datarisk' (public group)
-        group_token : str, optional
+            Group the preprocessing is inserted.
+        group_token : Optional[str], optional
             Token for executing the preprocessing (show when creating a group). It can be informed when getting the preprocessing or when running predictions, or using the env variable MLOPS_GROUP_TOKEN
-        wait_for_ready : bool
-            If the preprocessing is being deployed, wait for it to be ready instead of failing the request. Defaults to True
+        wait_for_ready : Optional[bool], optional
+            If the preprocessing is being deployed, wait for it to be ready instead of failing the request. Defaults to True.
 
         Raises
         ------
@@ -616,15 +621,15 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         """
         Search for preprocessing using the name of the preprocessing
 
-        Arguments
-        ---------
-        name : str, optional
+        Parameters
+        ----------
+        name : Optional[str], optional
             Text that it's expected to be on the preprocessing name. It runs similar to a LIKE query on SQL
-        state : str, optional
+        state : Optional[str], optional
             Text that it's expected to be on the state. It runs similar to a LIKE query on SQL
-        group : str, optional
+        group : Optional[str], optional
             Text that it's expected to be on the group name. It runs similar to a LIKE query on SQL
-        only_deployed : bool, optional
+        only_deployed : Optional[bool], optional
             If it's True, filter only preprocessing ready to be used (status == "Deployed"). Defaults to False
 
         Raises
@@ -635,7 +640,7 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         Returns
         -------
         list
-            List with the preprocessing data, it can works like a filter depending on the arguments values
+            A list with the preprocessing data, it can works like a filter depending on the arguments values
         Example
         -------
         >>> client.search_preprocessing(group='ex_group', only_deployed=True)
@@ -704,11 +709,11 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
             Pre processing id (hash)
         start : str, optional
             Date to start filter. At the format aaaa-mm-dd
-        end : str, optional
+        end : Optional[str], optional
             Date to end filter. At the format aaaa-mm-dd
-        routine : str, optional
+        routine : Optional[str], optional
             Type of routine being executed, can assume values 'Host' (for deployment logs) or 'Run' (for execution logs)
-        type : str, optional
+        type : Optional[str], optional
             Defines the type of the logs that are going to be filtered, can assume the values 'Ok', 'Error', 'Debug' or 'Warning'
 
         Raises
@@ -718,7 +723,7 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
 
         Returns
         -------
-        json
+        dict
             Logs list
 
         Example
@@ -760,8 +765,8 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         """
         Upload the files to the server
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         preprocessing_name : str
             The name of the preprocessing, in less than 32 characters
         preprocessing_reference : str
@@ -876,8 +881,8 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         """
         Builds the preprocessing execution environment
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         operation : str
             The preprocessing operation type (Sync or Async)
         preprocessing_id : str
@@ -943,8 +948,8 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         """
         Deploy a new preprocessing to MLOps.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         preprocessing_name : str
             The name of the preprocessing, in less than 32 characters
         preprocessing_reference : str
@@ -953,21 +958,21 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
             Path of the source file. The file must have a scoring function that accepts two parameters: data (data for the request body of the preprocessing) and preprocessing_path (absolute path of where the file is located)
         requirements_file : str
             Path of the requirements file. The packages versions must be fixed eg: pandas==1.0
-        schema : Union[str, dict]
-            Path to a JSON or XML file with a sample of the input for the entrypoint function. A dict with the sample input can be sending as well. Mandatory for Sync preprocessing
         group : str
-            Group the preprocessing is inserted. Default to 'datarisk' (public group)
-        extra_files : list, optional
+            Group the preprocessing is inserted.
+        schema : Optional[Union[str, dict]]
+            Path to a JSON or XML file with a sample of the input for the entrypoint function. A dict with the sample input can be sending as well. Mandatory for Sync preprocessing
+        extra_files : Optional[list], optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file
-        env : str, optional
+        env : Optional[str], optional
             Flag that choose which environment (dev, staging, production) of MLOps you are using. Default is True
-        python_version : str, optional
+        python_version : Optional[str], optional
             Python version for the preprocessing environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.8'
         operation : str
             Defines wich kind operation is beeing executed (Sync or Async). Default value is Sync
         input_type : str
             The type of the input file that should be 'json', 'csv' or 'parquet'
-        wait_for_ready : bool, optional
+        wait_for_ready : Optional[bool], optional
             Wait for preprocessing to be ready and returns a MLOpsPreprocessing instace with the new preprocessing. Defaults to True
 
         Raises
@@ -1016,10 +1021,10 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         self, preprocessing_id: str, exec_id: str, group: Optional[str] = None
     ) -> MLOpsExecution:
         """
-        Get a execution instace (Async preprocessing only).
+        Get an execution instace (Async preprocessing only).
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         preprocessing_id : str
             Pre processing id (hash)
         exec_id : str

--- a/src/mlops_codex/preprocessing.py
+++ b/src/mlops_codex/preprocessing.py
@@ -961,7 +961,9 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         group: str
             Group the preprocessing is inserted.
         schema: Optional[Union[str, dict]]
-            Path to a JSON or XML file with a sample of the input for the entrypoint function. A dict with the sample input can be sending as well. Mandatory for Sync preprocessing
+            Path to a JSON, XML, CSV or PARQUET file with a sample of the input for the entrypoint function. A dict with the sample input can be sending as well.
+            For async models, send a parquet or csv file
+            For sync models, send a json or xml file
         extra_files: Optional[list], optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file
         env: Optional[str], optional

--- a/src/mlops_codex/training.py
+++ b/src/mlops_codex/training.py
@@ -103,56 +103,76 @@ class MLOpsTrainingLogger:
         """
         Save the trained model to the logger.
 
-        Args:
-            model: The trained model.
+        Parameters
+        ----------
+        model : object
+            The trained model.
         """
+
         self.model = model
 
     def save_metric(self, *, name, value):
         """
         Save a metric to the logger.
 
-        Args:
-            name: The name of the metric.
-            value: The value of the metric.
+        Parameters
+        ----------
+        name : str
+            The name of the metric.
+        value : float
+            The value of the metric.
         """
+
         self.metrics[name] = value
 
     def save_model_output(self, model_output):
         """
         Save the model output to the logger.
 
-        Args:
-            model_output: The output of the trained model.
+        Parameters
+        ----------
+        model_output : object
+            The output of the trained model.
         """
+
         self.model_outputs = model_output
 
     def set_python_version(self, version: str):
         """
         Set the Python version used to train the model.
 
-        Args:
-            version: The Python version.
+        Parameters
+        ----------
+        version : str
+            The Python version.
         """
+
         self.python_version = version
 
     def set_requirements(self, requirements: str):
         """
         Set the project requirements.
 
-        Args:
-            requirements: The path of project requirements.
+        Parameters
+        ----------
+        requirements : str
+            The path of project requirements.
         """
+
         self.requirements = requirements
 
     def save_plot(self, *, plot: object, save_filename: str):
         """
         Save plot graphic image to the logger.
 
-        Args:
-            plot: A Matplotlib/Plotly/Seaborn graphic object.
-            save_filename: A name to save the plot.
+        Parameters
+        ----------
+        plot : object
+            A Matplotlib/Plotly/Seaborn graphic object.
+        save_filename : str
+            A name to save the plot.
         """
+
         filepath = f"./{save_filename}.png"
 
         with try_import() as plotly_import:
@@ -192,19 +212,26 @@ class MLOpsTrainingLogger:
         """
         Set the extra files list.
 
-        Args:
-            extra: A list of paths of the extra file.
+        Parameters
+        ----------
+        extra : list
+            A list of paths of the extra files.
         """
+
         self.extras = extra
 
     def add_extra(self, *, extra: Union[pd.DataFrame, str], filename: str = None):
         """
         Add an extra file in the extra file list.
 
-        Args:
-            extra: A path of an extra file or a list to include in extra file list.
-            filename: A filename if the extra it's a DataFrame.
+        Parameters
+        ----------
+        extra : Union[pd.DataFrame, str]
+            A path of an extra file or a list to include in extra file list.
+        filename : Optional[str], optional
+            A filename if the extra is a DataFrame.
         """
+
         if isinstance(extra, str):
             if os.path.exists(extra):
                 self.extras.append(extra)
@@ -222,9 +249,12 @@ class MLOpsTrainingLogger:
         """
         Add requirements file.
 
-        Args:
-            filename: The name of output filename to save.
+        Parameters
+        ----------
+        filename : str
+            The name of output filename to save.
         """
+
         self.requirements = filename
 
     def __to_parquet(self, *, output_filename: str, input_data: pd.DataFrame):
@@ -367,29 +397,29 @@ class MLOpsTrainingExecution(MLOpsExecution):
     """
     Class to manage trained models.
 
-    Attributes
+    Parameters
     ----------
     training_id : str
         Training id (hash) from the experiment you want to access
     group : str
-        Group the training is inserted. Default is 'datarisk' (public group)
+        Group the training is inserted.
     exec_id : str
-        Executiong id for that especific training run
+        Execution id for that specific training run
     login : str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
     password : str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
     environment : str
-        Enviroment of MLOps you are using.
+        Environment of MLOps you are using.
     run_data : dict
         Metadata from the execution.
 
     Raises
     ------
     TrainingError
-        When the training can't be acessed in the server
+        When the training can't be accessed in the server
     AuthenticationError
-        Unvalid credentials
+        Invalid credentials
 
     Example
     -------
@@ -461,7 +491,7 @@ class MLOpsTrainingExecution(MLOpsExecution):
         """
         Upload the files to the server
 
-        Arguments
+        Parameters
         ---------
         model_name : str
             The name of the model, in less than 32 characters
@@ -613,7 +643,7 @@ class MLOpsTrainingExecution(MLOpsExecution):
         """
         Builds the model execution environment
 
-        Arguments
+        Parameters
         ----------
         operation : str
             The model operation type (Sync or Async)
@@ -667,7 +697,7 @@ class MLOpsTrainingExecution(MLOpsExecution):
         """
         Upload models trained inside MLOps.
 
-        Arguments
+        Parameters
         ---------
         model_name : str
             The name of the model, in less than 32 characters
@@ -761,7 +791,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
     """
     Class to manage models being trained inside MLOps
 
-    Attributes
+    Parameters
     ----------
     login : str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
@@ -888,7 +918,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
         """
         Upload the files to the server
 
-        Arguments
+        Parameters
         ---------
         run_name : str
             The name of the model, in less than 32 characters
@@ -896,33 +926,33 @@ class MLOpsTrainingExperiment(BaseMLOps):
             Path of the file with train data
         training_type : str
             Can be Custom, AutoML or External
-        description : str, optional
+        description : Optional[str], optional
             Description of the experiment
-        training_reference : str, optional
+        training_reference : Optional[str], optional
             The name of the training function inside the source file. Just used when training_type is Custom
         python_version : str
             Python version for the model environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom
-        conf_dict : Union[str, dict], optional
+        conf_dict : Optional[Union[str, dict]], optional
             Path to a JSON file with the AutoML configuration. A dict can be sending as well. Just used when training_type is AutoML
-        source_file : str, optional
+        source_file : Optional[str], optional
             Path of the source file. The file must have a training function that accepts one parameter: model_path (absolute path of where the file is located). Just used when training_type is Custom
-        requirements_file : str, optional
+        requirements_file : Optional[str], optional
             Path of the requirements file. The packages versions must be fixed eg: pandas==1.0. Just used when training_type is Custom
-        env : str, optional
+        env : Optional[str], optional
             .env file to be used in your training environment. This will be encrypted in the server.
-        extra_files : list, optional
+        extra_files : Optional[list], optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file. Just used when training_type is Custom
-        X_train: pd.DataFrame, optional
+        X_train: Optional[pd.DataFrame], optional
             The training data.
-        y_train : pd.Series, optional
+        y_train : Optional[pd.Series], optional
             The training labels.
-        model_outputs : pd.DataFrame, optional
+        model_outputs : Optional[pd.DataFrame], optional
             The model outputs.
-        model_file : str, optional
+        model_file : Optional[str], optional
             The path to the trained model file.
-        model_metrics : Union[str, dict], optional
+        model_metrics : Optional[Union[str, dict]], optional
             The path to a JSON file with the model metrics or a dictionary with the metrics.
-        model_params : Union[str, dict], optional
+        model_params : Optional[Union[str, dict]], optional
             The path to a JSON file with the model parameters or a dictionary with the parameters.
 
         Raises
@@ -1066,7 +1096,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
         """
         Builds the model execution environment
 
-        Arguments
+        Parameters
         ---------
         exec_id : str
             The uploaded training execution id (hash)
@@ -1165,31 +1195,31 @@ class MLOpsTrainingExperiment(BaseMLOps):
         """
         Runs a prediction from the current model.
 
-        Arguments
+        Parameters
         ---------
         run_name : str
             The name of the model, in less than 32 characters
         train_data : str
             Path of the file with train data.
-        training_reference : str, optional
+        training_reference : Optional[str], optional
             The name of the training function inside the source file. Just used when training_type is Custom
         training_type : str
             Can be Custom, AutoML or External
-        description : str, optional
+        description : Optional[str], optional
             Description of the experiment
-        python_version : str, optional
+        python_version : Optional[str], optional
             Python version for the model environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom
         conf_dict : Union[str, dict]
             Path to a JSON file with the AutoML configuration. A dict can be sending as well. Just used when training_type is AutoML
-        source_file : str, optional
+        source_file : Optional[str], optional
             Path of the source file. The file must have a training function that accepts one parameter: model_path (absolute path of where the file is located). Just used when training_type is Custom
         requirements_file : str
             Path of the requirements file. The packages versions must be fixed eg: pandas==1.0. Just used when training_type is Custom
-        env : str, optional
+        env : Optional[str], optional
             .env file to be used in your training enviroment. This will be encrypted in the server.
-        extra_files : list, optional
+        extra_files : Optional[list], optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file. Just used when training_type is Custom
-        wait_complete : bool, optional
+        wait_complete : Optional[bool], optional
             Boolean that informs if a model training is completed (True) or not (False). Default value is False
 
         Raises
@@ -1337,9 +1367,9 @@ class MLOpsTrainingExperiment(BaseMLOps):
         """
         Get the execution instance.
 
-        Arguments
+        Parameters
         ---------
-        exec_id : str, optional
+        exec_id : Optional[str], optional
             Execution id. If not informed we get the last execution.
 
         Returns
@@ -1424,7 +1454,7 @@ class MLOpsTrainingClient(BaseMLOpsClient):
     """
     Class for client for accessing MLOps and manage models
 
-    Attributes
+    Parameters
     ----------
     login : str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
@@ -1460,17 +1490,17 @@ class MLOpsTrainingClient(BaseMLOpsClient):
         return f"MLOPS {self.base_url} Training client:{self.user_token}"
 
     def get_training(
-        self, *, training_id: str, group: str = "datarisk"
+        self, *, training_id: str, group: str
     ) -> MLOpsTrainingExperiment:
         """
         Acess a model using its id
 
-        Arguments
+        Parameters
         ---------
         training_id : str
             Training id (hash) that needs to be acessed
         group : str
-            Group the model is inserted. Default is 'datarisk' (public group)
+            Group the model is inserted.
 
         Raises
         ------
@@ -1639,7 +1669,7 @@ class MLOpsTrainingClient(BaseMLOpsClient):
         """
         Create a new training experiment on MLOps.
 
-        Arguments
+        Parameters
         ---------
         experiment_name : str
             The name of the experiment, in less than 32 characters
@@ -1647,7 +1677,7 @@ class MLOpsTrainingClient(BaseMLOpsClient):
             The name of the scoring function inside the source file.
         group : str
             Group the model is inserted. Default to 'datarisk' (public group)
-        force: bool
+        force: Optional[bool], optional
             Forces to create a new training with the same model_type, experiment_name, group
 
         Raises

--- a/src/mlops_codex/training.py
+++ b/src/mlops_codex/training.py
@@ -800,7 +800,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
     training_id : str
         Training id (hash) from the experiment you want to access
     group : str
-        Group the training is inserted. Default is 'datarisk' (public group)
+        Group the training is inserted.
     environment : str
         Flag that choose which environment of MLOps you are using. Test your deployment first before changing to production. Default is True
     executions : List[int]
@@ -901,7 +901,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
         train_data: Optional[str] = None,
         dataset: Union[str, MLOpsDataset] = None,
         training_reference: Optional[str] = None,
-        python_version: str = "3.8",
+        python_version: str = "3.10",
         conf_dict: Optional[Union[str, dict]] = None,
         source_file: Optional[str] = None,
         requirements_file: Optional[str] = None,
@@ -931,7 +931,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
         training_reference : Optional[str], optional
             The name of the training function inside the source file. Just used when training_type is Custom
         python_version : str
-            Python version for the model environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom
+            Python version for the model environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.10'. Just used when training_type is Custom
         conf_dict : Optional[Union[str, dict]], optional
             Path to a JSON file with the AutoML configuration. A dict can be sending as well. Just used when training_type is AutoML
         source_file : Optional[str], optional
@@ -1177,7 +1177,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
         train_data: Optional[str] = None,
         dataset: Union[str, MLOpsDataset] = None,
         training_reference: Optional[str] = None,
-        python_version: str = "3.8",
+        python_version: str = "3.10",
         conf_dict: Optional[Union[str, dict]] = None,
         source_file: Optional[str] = None,
         requirements_file: Optional[str] = None,
@@ -1208,7 +1208,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
         description : Optional[str], optional
             Description of the experiment
         python_version : Optional[str], optional
-            Python version for the model environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom
+            Python version for the training environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.10'
         conf_dict : Union[str, dict]
             Path to a JSON file with the AutoML configuration. A dict can be sending as well. Just used when training_type is AutoML
         source_file : Optional[str], optional
@@ -1282,7 +1282,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
 
         if python_version not in ["3.8", "3.9", "3.10"]:
             raise InputError(
-                "Invalid python version. Available versions are 3.8, 3.9, 3.10"
+                "Invalid python version. Available versions are 3.8, 3.9 and 3.10"
             )
 
         if training_type not in ["Custom", "AutoML", "External"]:

--- a/src/mlops_codex/training.py
+++ b/src/mlops_codex/training.py
@@ -105,7 +105,7 @@ class MLOpsTrainingLogger:
 
         Parameters
         ----------
-        model : object
+        model: object
             The trained model.
         """
 
@@ -117,9 +117,9 @@ class MLOpsTrainingLogger:
 
         Parameters
         ----------
-        name : str
+        name: str
             The name of the metric.
-        value : float
+        value: float
             The value of the metric.
         """
 
@@ -131,7 +131,7 @@ class MLOpsTrainingLogger:
 
         Parameters
         ----------
-        model_output : object
+        model_output: object
             The output of the trained model.
         """
 
@@ -143,7 +143,7 @@ class MLOpsTrainingLogger:
 
         Parameters
         ----------
-        version : str
+        version: str
             The Python version.
         """
 
@@ -155,7 +155,7 @@ class MLOpsTrainingLogger:
 
         Parameters
         ----------
-        requirements : str
+        requirements: str
             The path of project requirements.
         """
 
@@ -167,9 +167,9 @@ class MLOpsTrainingLogger:
 
         Parameters
         ----------
-        plot : object
+        plot: object
             A Matplotlib/Plotly/Seaborn graphic object.
-        save_filename : str
+        save_filename: str
             A name to save the plot.
         """
 
@@ -214,7 +214,7 @@ class MLOpsTrainingLogger:
 
         Parameters
         ----------
-        extra : list
+        extra: list
             A list of paths of the extra files.
         """
 
@@ -226,9 +226,9 @@ class MLOpsTrainingLogger:
 
         Parameters
         ----------
-        extra : Union[pd.DataFrame, str]
+        extra: Union[pd.DataFrame, str]
             A path of an extra file or a list to include in extra file list.
-        filename : Optional[str], optional
+        filename: Optional[str], optional
             A filename if the extra is a DataFrame.
         """
 
@@ -251,7 +251,7 @@ class MLOpsTrainingLogger:
 
         Parameters
         ----------
-        filename : str
+        filename: str
             The name of output filename to save.
         """
 
@@ -399,19 +399,19 @@ class MLOpsTrainingExecution(MLOpsExecution):
 
     Parameters
     ----------
-    training_id : str
+    training_id: str
         Training id (hash) from the experiment you want to access
-    group : str
+    group: str
         Group the training is inserted.
-    exec_id : str
+    exec_id: str
         Execution id for that specific training run
-    login : str
+    login: str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
-    environment : str
+    environment: str
         Environment of MLOps you are using.
-    run_data : dict
+    run_data: dict
         Metadata from the execution.
 
     Raises
@@ -493,23 +493,23 @@ class MLOpsTrainingExecution(MLOpsExecution):
 
         Parameters
         ---------
-        model_name : str
+        model_name: str
             The name of the model, in less than 32 characters
-        model_reference : str, optional
+        model_reference: Optional[str], optional
             The name of the scoring function inside the source file
-        source_file : str, optional
+        source_file: Optional[str], optional
             Path of the source file. The file must have a scoring function that accepts two parameters: data (data for the request body of the model) and model_path (absolute path of where the file is located)
-        schema : Union[str, dict], optional
+        schema: Union[str, dict], optional
             Path to a JSON or XML file with a sample of the input for the entrypoint function. A dict with the sample input can be sending as well
-        extra_files list, optional
+        extra_files: Optional[list], optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file
-        requirements_file : str, optional
+        requirements_file: Optional[str], optional
             Path of the requirements file. This will override the requirements used in training. The packages versions must be fixed eg: pandas==1.0
-        env : str, optional
+        env: Optional[str], optional
             Flag that choose which environment (dev, staging, production) of MLOps you are using. Default is None
-        operation : str
+        operation: str
             Defines which kind operation is being executed (Sync or Async). Default value is Sync
-        input_type : str
+        input_type: str
             The type of the input file that should be 'json', 'csv' or 'parquet'
 
         Raises
@@ -645,9 +645,9 @@ class MLOpsTrainingExecution(MLOpsExecution):
 
         Parameters
         ----------
-        operation : str
+        operation: str
             The model operation type (Sync or Async)
-        model_id : str
+        model_id: str
             The uploaded model id (hash)
 
         Raises
@@ -699,23 +699,23 @@ class MLOpsTrainingExecution(MLOpsExecution):
 
         Parameters
         ---------
-        model_name : str
+        model_name: str
             The name of the model, in less than 32 characters
-        model_reference : str, optional
+        model_reference: Optional[str], optional
             The name of the scoring function inside the source file
-        source_file : str, optional
+        source_file: Optional[str], optional
             Path of the source file. The file must have a scoring function that accepts two parameters: data (data for the request body of the model) and model_path (absolute path of where the file is located)
-        schema : Union[str, dict], optional
+        schema: Union[str, dict], optional
             Path to a JSON or XML file with a sample of the input for the entrypoint function. A dict with the sample input can be sending as well
         extra_files: list, optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file
-        requirements_file : str, optional
+        requirements_file: str, optional
             Path of the requirements file. This will override the requirements used in trainning. The packages versions must be fixed eg: pandas==1.0
-        env : str, optional
+        env: str, optional
             Flag that choose which environment (dev, staging, production) of MLOps you are using. Default is True
-        operation : str
+        operation: str
             Defines which kind operation is being executed (Sync or Async). Default value is Sync
-        input_type : str
+        input_type: str
             The type of the input file that should be 'json', 'csv' or 'parquet'
 
         Raises
@@ -793,17 +793,17 @@ class MLOpsTrainingExperiment(BaseMLOps):
 
     Parameters
     ----------
-    login : str
+    login: str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
-    training_id : str
+    training_id: str
         Training id (hash) from the experiment you want to access
-    group : str
+    group: str
         Group the training is inserted.
-    environment : str
+    environment: str
         Flag that choose which environment of MLOps you are using. Test your deployment first before changing to production. Default is True
-    executions : List[int]
+    executions: List[int]
         Ids for the executions in that training
 
 
@@ -920,39 +920,39 @@ class MLOpsTrainingExperiment(BaseMLOps):
 
         Parameters
         ---------
-        run_name : str
+        run_name: str
             The name of the model, in less than 32 characters
-        train_data : str
+        train_data: str
             Path of the file with train data
-        training_type : str
+        training_type: str
             Can be Custom, AutoML or External
-        description : Optional[str], optional
+        description: Optional[str], optional
             Description of the experiment
-        training_reference : Optional[str], optional
+        training_reference: Optional[str], optional
             The name of the training function inside the source file. Just used when training_type is Custom
-        python_version : str
+        python_version: str
             Python version for the model environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.10'. Just used when training_type is Custom
-        conf_dict : Optional[Union[str, dict]], optional
+        conf_dict: Optional[Union[str, dict]], optional
             Path to a JSON file with the AutoML configuration. A dict can be sending as well. Just used when training_type is AutoML
-        source_file : Optional[str], optional
+        source_file: Optional[str], optional
             Path of the source file. The file must have a training function that accepts one parameter: model_path (absolute path of where the file is located). Just used when training_type is Custom
-        requirements_file : Optional[str], optional
+        requirements_file: Optional[str], optional
             Path of the requirements file. The packages versions must be fixed eg: pandas==1.0. Just used when training_type is Custom
-        env : Optional[str], optional
+        env: Optional[str], optional
             .env file to be used in your training environment. This will be encrypted in the server.
-        extra_files : Optional[list], optional
+        extra_files: Optional[list], optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file. Just used when training_type is Custom
         X_train: Optional[pd.DataFrame], optional
             The training data.
-        y_train : Optional[pd.Series], optional
+        y_train: Optional[pd.Series], optional
             The training labels.
-        model_outputs : Optional[pd.DataFrame], optional
+        model_outputs: Optional[pd.DataFrame], optional
             The model outputs.
-        model_file : Optional[str], optional
+        model_file: Optional[str], optional
             The path to the trained model file.
-        model_metrics : Optional[Union[str, dict]], optional
+        model_metrics: Optional[Union[str, dict]], optional
             The path to a JSON file with the model metrics or a dictionary with the metrics.
-        model_params : Optional[Union[str, dict]], optional
+        model_params: Optional[Union[str, dict]], optional
             The path to a JSON file with the model parameters or a dictionary with the parameters.
 
         Raises
@@ -1098,7 +1098,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
 
         Parameters
         ---------
-        exec_id : str
+        exec_id: str
             The uploaded training execution id (hash)
 
         Raises
@@ -1197,29 +1197,29 @@ class MLOpsTrainingExperiment(BaseMLOps):
 
         Parameters
         ---------
-        run_name : str
+        run_name: str
             The name of the model, in less than 32 characters
-        train_data : str
+        train_data: str
             Path of the file with train data.
-        training_reference : Optional[str], optional
+        training_reference: Optional[str], optional
             The name of the training function inside the source file. Just used when training_type is Custom
-        training_type : str
+        training_type: str
             Can be Custom, AutoML or External
-        description : Optional[str], optional
+        description: Optional[str], optional
             Description of the experiment
-        python_version : Optional[str], optional
+        python_version: Optional[str], optional
             Python version for the training environment. Available versions are 3.8, 3.9, 3.10. Defaults to '3.10'
-        conf_dict : Union[str, dict]
+        conf_dict: Union[str, dict]
             Path to a JSON file with the AutoML configuration. A dict can be sending as well. Just used when training_type is AutoML
-        source_file : Optional[str], optional
+        source_file: Optional[str], optional
             Path of the source file. The file must have a training function that accepts one parameter: model_path (absolute path of where the file is located). Just used when training_type is Custom
-        requirements_file : str
+        requirements_file: str
             Path of the requirements file. The packages versions must be fixed eg: pandas==1.0. Just used when training_type is Custom
-        env : Optional[str], optional
+        env: Optional[str], optional
             .env file to be used in your training enviroment. This will be encrypted in the server.
-        extra_files : Optional[list], optional
+        extra_files: Optional[list], optional
             A optional list with additional files paths that should be uploaded. If the scoring function refer to this file they will be on the same folder as the source file. Just used when training_type is Custom
-        wait_complete : Optional[bool], optional
+        wait_complete: Optional[bool], optional
             Boolean that informs if a model training is completed (True) or not (False). Default value is False
 
         Raises
@@ -1369,7 +1369,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
 
         Parameters
         ---------
-        exec_id : Optional[str], optional
+        exec_id: Optional[str], optional
             Execution id. If not informed we get the last execution.
 
         Returns
@@ -1456,11 +1456,11 @@ class MLOpsTrainingClient(BaseMLOpsClient):
 
     Parameters
     ----------
-    login : str
+    login: str
         Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
-    password : str
+    password: str
         Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
-    url : str
+    url: str
         URL to MLOps Server. Default value is https://neomaril.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
 
     Raises
@@ -1497,9 +1497,9 @@ class MLOpsTrainingClient(BaseMLOpsClient):
 
         Parameters
         ---------
-        training_id : str
+        training_id: str
             Training id (hash) that needs to be acessed
-        group : str
+        group: str
             Group the model is inserted.
 
         Raises
@@ -1671,11 +1671,11 @@ class MLOpsTrainingClient(BaseMLOpsClient):
 
         Parameters
         ---------
-        experiment_name : str
+        experiment_name: str
             The name of the experiment, in less than 32 characters
-        model_type : str
+        model_type: str
             The name of the scoring function inside the source file.
-        group : str
+        group: str
             Group the model is inserted. Default to 'datarisk' (public group)
         force: Optional[bool], optional
             Forces to create a new training with the same model_type, experiment_name, group


### PR DESCRIPTION
## Description

With this pr:
- Revise all documentation; 
- Resolve the issue of code blocks not displaying in Sphinx.;
- Correct typographical and grammatical errors;
- Remove 'datarisk' as default parameters from different functions
- Adjust parameters, raises and returns from functions;
-  Improve readability (in my opinion);
- Fix conflict between return type annotation and actual return

## Related issues

- Closes: https://linear.app/datarisk/issue/NEODV-1517/[techdebt]-atualizar-a-pagina-de-documentacao-do-codex

## How to test it

Run sphinx in your machine and see the result

 
 
 
 **PR Summary by Typo**
------------

 **Summary**

This pull request includes various improvements to the documentation and codebase, such as updating links, renaming variables, and adding new features. Changes include:

1. Updating README links and renaming local variable names in docs.
2. Improving "tasource.rst" file by adding GCP support and changing code snippets.
3. Introducing a new way to retrieve a dataset using its DHash.
4. Changing import of environment variables from a code block to a `.env` file.
5. Allowing users to create a group with a description and disable/delete models.
6. Registering monitoring configurations for models using the `MLOpsPipeline.register_monitoring_config` method.
7. Adding support for running a preprocessing script before executing a model.

**Key Points**

1. Improved documentation and code consistency.
2. Added support for Google Cloud Platform (GCP) and new features.
3. Changed import of environment variables and added support for new clients.
4. Allowed users to create groups with descriptions and manage models.
5. Registered monitoring configurations for models using `MLOpsPipeline`.
6. Added support for running a preprocessing script before executing a model. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>