### PR TITLE
Refatorar outros endpoints de treino no codex neodv 1617

### DIFF
--- a/notebooks/TrainingV2.ipynb
+++ b/notebooks/TrainingV2.ipynb
@@ -1,0 +1,117 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": "from mlops_codex.training import MLOpsTrainingClient",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "client = MLOpsTrainingClient()\n",
+    "client"
+   ],
+   "id": "556a3fb73290a75b",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# Creating a new training experiment\n",
+    "training = client.create_training_experiment(\n",
+    "    experiment_name='experiment',\n",
+    "    model_type='Classification',\n",
+    "    group='<group>',\n",
+    ")"
+   ],
+   "id": "a8f129be78149bb1",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "training",
+   "id": "be81cf47890e1e6a",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# With the experiment class we can create multiple model runs\n",
+    "PATH = './samples/train/'\n",
+    "\n",
+    "run = training.run_training(\n",
+    "    run_name='First test',\n",
+    "    training_type='Custom',\n",
+    "    train_data=PATH + 'dados.csv',\n",
+    "    requirements_file=PATH + 'requirements.txt',\n",
+    "    source_file=PATH + 'app.py',\n",
+    "    python_version='3.9',\n",
+    "    training_reference='train_model',\n",
+    "    wait_complete=True\n",
+    ")"
+   ],
+   "id": "e7a4107da1c07f9",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "PATH = './samples/autoML/'\n",
+    "\n",
+    "run2 = training.run_training(\n",
+    "    run_name='First test',\n",
+    "    training_type='AutoML',\n",
+    "    conf_dict=PATH + \"conf.json\",\n",
+    "    train_data=PATH + 'dados.csv',\n",
+    "    wait_complete=True\n",
+    ")"
+   ],
+   "id": "816f785a26dcf617",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "",
+   "id": "1d8b38fedf20383b",
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/TrainingV2.ipynb
+++ b/notebooks/TrainingV2.ipynb
@@ -1,29 +1,89 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "77559178",
+   "metadata": {},
+   "source": [
+    "# MLOps Training\n",
+    "\n",
+    "This notebook give a exemple on how to use MLOps to training a ML model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18c9b0da",
+   "metadata": {},
+   "source": [
+    "### MLOpsTrainingClient\n",
+    "\n",
+    "It's where you can manage your trainining experiments"
+   ]
+  },
+  {
    "cell_type": "code",
+   "execution_count": null,
    "id": "initial_id",
    "metadata": {
     "collapsed": true
    },
-   "source": "from mlops_codex.training import MLOpsTrainingClient",
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "from mlops_codex.training import MLOpsTrainingClient"
+   ]
   },
   {
-   "metadata": {},
+   "cell_type": "markdown",
+   "id": "f47d2a5a",
+   "metadata": {
+    "vscode": {
+     "languageId": "markdown"
+    }
+   },
+   "source": [
+    "### Initializing the MLOpsTrainingClient\n",
+    "In this cell, we are initializing the `MLOpsTrainingClient` which will be used to manage our training experiments."
+   ]
+  },
+  {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "556a3fb73290a75b",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "client = MLOpsTrainingClient()\n",
     "client"
-   ],
-   "id": "556a3fb73290a75b",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
+   "cell_type": "markdown",
+   "id": "deb3a4c9",
    "metadata": {},
+   "source": [
+    "## MLOpsTrainingExperiment\n",
+    "\n",
+    "It's where you can create a training experiment to find the best model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09074b27",
+   "metadata": {},
+   "source": [
+    "#### Custom training\n",
+    "\n",
+    "With Custom training, you have to create the training function. For you, as a data scientist, it's common to re-run the entire notebook, over and over. To avoid creating the same experiment repeatedly, the `force = False` parameter will disallow it. If you wish to create a new experiment with the same attributes, turn `force = True`.\n",
+    "\n",
+    "If you have two equal experiments and pass `force = False`, the first created experiment will be chosen."
+   ]
+  },
+  {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "a8f129be78149bb1",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Creating a new training experiment\n",
     "training = client.create_training_experiment(\n",
@@ -31,22 +91,24 @@
     "    model_type='Classification',\n",
     "    group='<group>',\n",
     ")"
-   ],
-   "id": "a8f129be78149bb1",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "training",
+   "execution_count": null,
    "id": "be81cf47890e1e6a",
+   "metadata": {},
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "training"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "e7a4107da1c07f9",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# With the experiment class we can create multiple model runs\n",
     "PATH = './samples/train/'\n",
@@ -61,14 +123,24 @@
     "    training_reference='train_model',\n",
     "    wait_complete=True\n",
     ")"
-   ],
-   "id": "e7a4107da1c07f9",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
+   "cell_type": "markdown",
+   "id": "daedbd49",
    "metadata": {},
+   "source": [
+    "#### AutoML\n",
+    "\n",
+    "With AutoML you just need to upload the data and some configuration"
+   ]
+  },
+  {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "816f785a26dcf617",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "PATH = './samples/autoML/'\n",
     "\n",
@@ -79,18 +151,15 @@
     "    train_data=PATH + 'dados.csv',\n",
     "    wait_complete=True\n",
     ")"
-   ],
-   "id": "816f785a26dcf617",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "",
+   "execution_count": null,
    "id": "1d8b38fedf20383b",
+   "metadata": {},
    "outputs": [],
-   "execution_count": null
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/samples/train/requirements.txt
+++ b/notebooks/samples/train/requirements.txt
@@ -1,4 +1,4 @@
 pandas==1.4.0
 numpy==1.26.4
-lightgbm==3.3.2
+lightgbm==4.6.0
 scikit-learn==1.5.0

--- a/src/mlops_codex/__model_states.py
+++ b/src/mlops_codex/__model_states.py
@@ -7,6 +7,15 @@ application
 from enum import Enum
 
 
+class ModelTypes(str, Enum):
+
+    Async = "Async"
+    Sync = "Sync"
+
+    def __str__(self):
+        return self.name
+
+
 class ModelState(str, Enum):
     """
     States of a model

--- a/src/mlops_codex/dataset.py
+++ b/src/mlops_codex/dataset.py
@@ -9,6 +9,29 @@ from mlops_codex.logger_config import get_logger
 
 logger = get_logger()
 
+def validate_dataset(dataset):
+    """
+    Check if a dataset is a valid hash or a valid MLOps Dataset
+    Args:
+        dataset: dataset provided by the user
+
+    Returns:
+        str: if the dataset is a valid hash or a valid MLOps Dataset
+    """
+
+    if not isinstance(dataset, (MLOpsDataset, str)):
+        raise TypeError("Dataset must be a MLOpsDataset or str")
+
+    if isinstance(dataset, MLOpsDataset):
+        dataset_hash = dataset.hash
+    else:
+        dataset_hash = dataset
+
+    if not dataset_hash.startswith("D"):
+        raise ValueError("The provided dataset hash is not valid. Check your dataset hash")
+
+    return dataset_hash
+
 
 class MLOpsDatasetClient(BaseMLOpsClient):
     """

--- a/src/mlops_codex/external_monitoring.py
+++ b/src/mlops_codex/external_monitoring.py
@@ -200,9 +200,7 @@ class MLOpsExternalMonitoring(BaseMLOps):
                 logger.error(f"You must pass the following arguments: {missing_args}")
                 raise InputError("Missing files, function entrypoint or python version")
 
-        validate_python_version(python_version)
-
-        python_version = "Python" + python_version.replace(".", "")
+        python_version= validate_python_version(python_version)
 
         uploads = [
             ("model", model_file, "model-file", None),
@@ -584,8 +582,7 @@ class MLOpsExternalMonitoringClient(BaseMLOpsClient):
                 raise InputError("Date is not in the correct format") from exc
 
         if kwargs.get("python_version"):
-            validate_python_version(kwargs.get("python_version"))
-            python_version = "Python" + kwargs.get("python_version").replace(".", "")
+            python_version = validate_python_version(kwargs.get("python_version"))
             configuration_file["PythonVersion"] = python_version
 
         external_monitoring_hash = self.__register(

--- a/src/mlops_codex/model.py
+++ b/src/mlops_codex/model.py
@@ -1517,9 +1517,7 @@ class MLOpsModelClient(BaseMLOpsClient):
 
         file_extension_validation(source_file, {"py", "ipynb"})
         file_extension_validation(schema, {"csv", "parquet", "json"})
-        validate_python_version(python_version)
-
-        python_version = "Python" + python_version.replace(".", "")
+        python_version = validate_python_version(python_version)
 
         upload_data = [
             (
@@ -1635,7 +1633,6 @@ class MLOpsModelClient(BaseMLOpsClient):
 
         logger.info(f"Creating a new model {model_name}. Validating data")
 
-        validate_python_version(python_version)
         validate_group_existence(group, self)
 
         if operation.title() != "Sync" or operation.title() != "Async":

--- a/src/mlops_codex/pipeline.py
+++ b/src/mlops_codex/pipeline.py
@@ -189,7 +189,7 @@ class MLOpsPipeline(BaseMLOps):
 
         Example
         -------
-        >>> pipeline.run_training()
+        >>> pipeline.run_training(run_name=,training_type=)
         """
         logger.info("Running training")
         client = MLOpsTrainingClient(
@@ -210,48 +210,30 @@ class MLOpsPipeline(BaseMLOps):
         extra_files = conf.get("extra")
 
         if conf["training_type"] == "Custom":
-            self.__training_run = self.__training.run_training(
-                run_name=run_name,
-                training_type=conf["training_type"],
-                train_data=os.path.join(PATH, conf["data"]),
-                source_file=os.path.join(PATH, conf["source"]),
-                requirements_file=os.path.join(PATH, conf["packages"]),
-                training_reference=conf["train_function"],
-                extra_files=(
+            self.__training_run = self.__training.run_training(run_name=run_name, training_type=conf["training_type"],
+                                                               requirements_file=os.path.join(PATH, conf["packages"]),
+                                                               source_file=os.path.join(PATH, conf["source"]),
+                                                               python_version=str(self.python_version),
+                                                               training_reference=conf["train_function"], extra_files=(
                     [os.path.join(PATH, e) for e in extra_files]
                     if extra_files
                     else None
-                ),
-                python_version=str(self.python_version),
-                wait_complete=True,
-            )
+                ), wait_complete=True)
 
         elif conf["training_type"] == "AutoML":
-            self.__training_run = self.__training.run_training(
-                run_name=run_name,
-                training_type=os.path.join(PATH, conf["data"]),
-                conf_dict=os.path.join(PATH, conf["config"]),
-                wait_complete=True,
-            )
+            self.__training_run = self.__training.run_training(run_name=run_name,
+                                                               training_type=os.path.join(PATH, conf["data"]),
+                                                               conf_dict=os.path.join(PATH, conf["config"]),
+                                                               wait_complete=True)
 
         elif conf["training_type"] == "External":
-            self.__training_run = self.__training.run_training(
-                run_name=run_name,
-                training_type=conf["training_type"],
-                X_train=os.path.join(PATH, conf["X_train"]),
-                y_train=os.path.join(PATH, conf["y_train"]),
-                model_outputs=os.path.join(PATH, conf["model_outputs"]),
-                model_file=conf["model_file"],
-                model_metrics=conf["model_metrics"],
-                model_params=conf["model_params"],
-                python_version=conf["python_version"],
-                extra_files=(
+            self.__training_run = self.__training.run_training(run_name=run_name, training_type=conf["training_type"],
+                                                               python_version=conf["python_version"],
+                                                               model_file=conf["model_file"], extra_files=(
                     [os.path.join(PATH, e) for e in extra_files]
                     if extra_files
                     else None
-                ),
-                wait_complete=True,
-            )
+                ), wait_complete=True)
         else:
             raise TrainingError(
                 f"Invalid training_type {conf['training_type']}. Valid options are Custom, AutoML and External"
@@ -260,7 +242,7 @@ class MLOpsPipeline(BaseMLOps):
         status = self.__training_run.get_status()
         if status["Status"] == "Succeeded":
             logger.info("Model training finished")
-            return self.__training.training_id, self.__training_run.exec_id
+            return self.__training.training_hash, self.__training_run.exec_id
         else:
             raise TrainingError("Training failed: " + status["Message"])
 

--- a/src/mlops_codex/preprocessing.py
+++ b/src/mlops_codex/preprocessing.py
@@ -484,9 +484,7 @@ class MLOpsPreprocessingAsyncV2Client(BaseMLOpsClient):
             )
 
         validate_group_existence(group, self)
-        validate_python_version(python_version)
-
-        python_version = "Python" + python_version.replace(".", "")
+        python_version = validate_python_version(python_version)
 
         token = refresh_token(*self.credentials, self.base_url)
 
@@ -2409,7 +2407,6 @@ class MLOpsPreprocessingClient(BaseMLOpsClient):
         """
 
         validate_group_existence(group, self)
-        validate_python_version(python_version)
 
         if operation == "Async":
             preprocessing_id = self.__new_preprocessing_client.create(

--- a/src/mlops_codex/shared/constants.py
+++ b/src/mlops_codex/shared/constants.py
@@ -1,0 +1,1 @@
+CODEX_VERSION = "2.2.8"

--- a/src/mlops_codex/training/__init__.py
+++ b/src/mlops_codex/training/__init__.py
@@ -1,1 +1,7 @@
 from .training import MLOpsTrainingExperiment, MLOpsTrainingClient, MLOpsTrainingLogger
+
+__all__ = [
+    "MLOpsTrainingExperiment",
+    "MLOpsTrainingClient",
+    "MLOpsTrainingLogger",
+]

--- a/src/mlops_codex/training/__init__.py
+++ b/src/mlops_codex/training/__init__.py
@@ -1,0 +1,1 @@
+from .training import MLOpsTrainingExperiment, MLOpsTrainingClient, MLOpsTrainingLogger

--- a/src/mlops_codex/training/base.py
+++ b/src/mlops_codex/training/base.py
@@ -39,7 +39,7 @@ class ITrainingExecution(BaseModel, abc.ABC):
             )
 
         url = f"{self.mlops_class.base_url}/training/describe/{self.group}/{self.training_hash}"
-        token = refresh_token(*self.mlops_class.credentials, self.base_url)
+        token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
 
         response = make_request(
             url=url,

--- a/src/mlops_codex/training/base.py
+++ b/src/mlops_codex/training/base.py
@@ -190,7 +190,7 @@ class ITrainingExecution(BaseModel, abc.ABC):
         return status
 
     def host(self):
-        url = f"{self.mlops_class.base_url}/training/execution/{self.execution_id}"
+        url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}"
         token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
 
         response = make_request(

--- a/src/mlops_codex/training/base.py
+++ b/src/mlops_codex/training/base.py
@@ -98,7 +98,8 @@ class ITrainingExecution(BaseModel, abc.ABC):
         msg = response.json()["Message"]
         dataset_hash = response.json()["DatasetHash"]
 
-        logger.info(f"{msg}.\nDataset hash = {dataset_hash}")
+        logger.info(f"{msg}")
+        logger.info(f"Dataset hash = {dataset_hash}")
 
     def _upload_requirements(self, requirements_file: str):
         url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}/requirements-file"

--- a/src/mlops_codex/training/base.py
+++ b/src/mlops_codex/training/base.py
@@ -2,7 +2,7 @@ import abc
 from time import sleep
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from mlops_codex.__model_states import ModelExecutionState
 from mlops_codex.base import BaseMLOps
@@ -15,16 +15,16 @@ logger = get_logger()
 
 
 class ITrainingExecution(BaseModel, abc.ABC):
-    training_hash: str
-    group: str
-    execution_id: int = None
-    model_type: str = None
-    experiment_name: str = None
-    # TODO: not show these variables above!!
-    login: str = None
-    password: str = None
-    url: str = "https://neomaril.datarisk.net/"
-    mlops_class: BaseMLOps = None
+    training_hash: str = Field(frozen=True, title="Training hash", validate_default=True)
+    group: str = Field(frozen=True, title="Training hash", validate_default=True)
+    execution_id: int = Field(default=None, gt=0)
+    model_type: str = Field(default=None)
+    experiment_name: str = Field(default=None)
+
+    login: str = Field(default=None, repr=False)
+    password: str = Field(default=None, repr=False)
+    url: str = Field(default="https://neomaril.datarisk.net/", repr=False)
+    mlops_class: BaseMLOps = Field(default=None, repr=False)
 
 
     class Config:

--- a/src/mlops_codex/training/base.py
+++ b/src/mlops_codex/training/base.py
@@ -177,8 +177,6 @@ class ITrainingExecution(BaseModel, abc.ABC):
             logger_msg=f"Experiment with execution id {self.execution_id} not found.",
             headers={
                 "Authorization": f"Bearer {token}",
-                "Neomaril-Origin": "Codex",
-                "Neomaril-Method": self.status.__qualname__,
             },
         ).json()
 

--- a/src/mlops_codex/training/base.py
+++ b/src/mlops_codex/training/base.py
@@ -1,0 +1,284 @@
+import abc
+from time import sleep
+from typing import Any
+
+from pydantic import BaseModel
+
+from mlops_codex.__model_states import ModelExecutionState
+from mlops_codex.base import BaseMLOps
+from mlops_codex.exceptions import TrainingError, InputError
+from mlops_codex.http_request_handler import refresh_token, make_request
+from mlops_codex.logger_config import get_logger
+from mlops_codex.model import SyncModel, AsyncModel
+
+logger = get_logger()
+
+
+class ITrainingExecution(BaseModel, abc.ABC):
+    training_hash: str
+    group: str
+    execution_id: int = None
+    model_type: str = None
+    experiment_name: str = None
+    # TODO: not show these variables above!!
+    login: str = None
+    password: str = None
+    url: str = "https://neomaril.datarisk.net/"
+    mlops_class: BaseMLOps = None
+
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+    def model_post_init(self, __context: Any) -> None:
+        if self.mlops_class is None:
+            self.mlops_class = BaseMLOps(login=self.login, password=self.password, url=self.url)
+
+        url = f"{self.mlops_class.base_url}/training/describe/{self.group}/{self.training_hash}"
+        token = refresh_token(*self.mlops_class.credentials, self.base_url)
+
+        response = make_request(
+            url=url,
+            method="GET",
+            success_code=200,
+            custom_exception=TrainingError,
+            custom_exception_message=f'Experiment "{self.training_hash}" not found.',
+            specific_error_code=404,
+            logger_msg=f'Experiment "{self.training_hash}" not found.',
+            headers={
+                f'Authorization': f'Bearer {token}',
+            }
+        )
+
+        training_data = response.json()["Description"]
+        self.model_type = training_data["ModelType"]
+        self.experiment_name = training_data["ExperimentName"]
+
+    def _register_execution(self, run_name: str, description: str, training_type: str):
+        url = f"{self.mlops_class.base_url}/v2/training/{self.training_hash}/execution"
+        token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
+        payload = {"RunName": run_name, "Description": description, "TrainingType": training_type}
+        response = make_request(
+            url=url,
+            method="POST",
+            success_code=201,
+            json=payload,
+            headers={"Authorization": f"Bearer {token}"}
+        )
+
+        msg = response.json().get("Message")
+        execution_id = response.json()["ExecutionId"]
+        logger.info(f"{msg} for {run_name}")
+        return execution_id
+
+    def _upload_input_file(self, input_data: str, upload_data: str):
+        url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}/input/file"
+        token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
+
+        response = make_request(
+            url=url,
+            method="PATCH",
+            success_code=201,
+            data=input_data,
+            files=upload_data,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self._upload_input_file.__qualname__,
+            }
+        )
+
+        msg = response.json()["Message"]
+        dataset_hash = response.json()["DatasetHash"]
+
+        logger.info(f"{msg}.\nDataset hash = {dataset_hash}")
+
+    def _upload_requirements(self, requirements_file: str):
+        url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}/requirements-file"
+        token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
+
+        upload_data = {"requirements": open(requirements_file, "rb")}
+
+        response = make_request(
+            url=url,
+            method="PATCH",
+            success_code=201,
+            files=upload_data,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self._upload_requirements.__qualname__,
+            }
+        )
+
+        msg = response.json()["Message"]
+        logger.info(msg)
+
+    def _upload_extra_files(self, extra_files_path: str, name: str):
+        url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}/extra-files"
+        token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
+
+        upload_data = {"extra": open(extra_files_path, "rb")}
+        input_data = {"file_name": name}
+        response = make_request(
+            url=url,
+            method="PATCH",
+            success_code=201,
+            data=input_data,
+            files=upload_data,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self._upload_extra_files.__qualname__,
+            }
+        )
+
+        msg = response.json()["Message"]
+        logger.info(msg)
+
+    def _upload_env_file(self, env_file: str):
+        url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}/env/file"
+        token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
+
+        upload_data = {"env": open(env_file, "rb")}
+        response = make_request(
+            url=url,
+            method="PATCH",
+            success_code=201,
+            files=upload_data,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self._upload_extra_files.__qualname__,
+            }
+        )
+
+        msg = response.json()["Message"]
+        logger.info(msg)
+
+    @property
+    def status(self) -> str:
+
+        url = f"{self.mlops_class.base_url}/training/execution/{self.execution_id}"
+        token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
+        response = make_request(
+            url=url,
+            method="GET",
+            success_code=200,
+            custom_exception=TrainingError,
+            custom_exception_message=f'Experiment with execution id {self.execution_id} not found.',
+            specific_error_code=404,
+            logger_msg=f'Experiment with execution id {self.execution_id} not found.',
+            headers={
+                f'Authorization': f'Bearer {token}',
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.status.__qualname__,
+            }
+        ).json()
+
+        status = response["Status"]
+        if status == "Failed":
+            msg = response["Message"]
+            logger.info(msg)
+
+        return status
+
+    def host(self):
+        url = f"{self.mlops_class.base_url}/training/execution/{self.execution_id}"
+        token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
+
+        response = make_request(
+            url=url,
+            method="PATCH",
+            success_code=202,
+            headers={
+                f'Authorization': f'Bearer {token}',
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.host.__qualname__,
+            }
+        ).json()
+
+        msg = response["Message"]
+        logger.info(msg)
+
+    def wait_ready(self):
+        current_status = ModelExecutionState.Running
+        print("Training your model...", end="", flush=True)
+        while current_status in [ModelExecutionState.Running, ModelExecutionState.Requested]:
+            current_status = ModelExecutionState[self.status]
+            sleep(30)
+            print(".", end="", flush=True)
+        print()
+
+        if current_status == ModelExecutionState.Succeeded:
+            logger.info("Training finished successfully.")
+        else:
+            logger.info(f"Training failed. Current status is {current_status}")
+
+    # TODO: update it when promote endpoint updated
+    def __promote_validation(self, **kwargs):
+
+        if kwargs["operation"] == "Async":
+            if kwargs["input_type"] is None:
+                raise InputError("For asynchronous models, you must provide the 'input_type' argument.")
+            if kwargs["schema_extension"]:
+                raise InputError("The input schema extension must be json, csv, parquet or xml.")
+
+        status = self.status
+        if status != "Succeeded":
+            raise TrainingError(
+                f"Training execution must be Succeeded to be promoted, current status is {status}"
+            )
+
+    def __promote(self, **kwargs):
+        url = f"{self.mlops_class.base_url}/training/promote/{self.group}/{self.training_hash}/{self.execution_id}"
+        token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
+
+        upload_data = kwargs.get("upload_data")
+        input_data = kwargs.get("input_data")
+
+        response = make_request(
+            url=url,
+            method="POST",
+            success_code=201,
+            data=input_data,
+            files=upload_data,
+            headers={
+                f'Authorization': f'Bearer {token}',
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.__promote.__qualname__,
+            }
+        )
+
+        msg = response.json()["Message"]
+        logger.info(msg)
+
+        model_hash = response["ModelHash"]
+        operation = kwargs["operation"]
+        model_name = kwargs["model_name"]
+
+        builder = SyncModel if operation.title() == "Sync" else AsyncModel
+        model = builder(
+            name=model_name,
+            model_hash=model_hash,
+            login=self.mlops_class.credentials[0],
+            password=self.mlops_class.credentials[1],
+            url=self.mlops_class.base_url,
+            group=self.group,
+        )
+
+        model.host(operation=operation.title())
+
+        wait_complete = kwargs.get("wait_complete", False)
+        if wait_complete:
+            model.wait_ready()
+
+        return model
+
+    @abc.abstractmethod
+    def promote(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def execution_info(self):
+        raise NotImplementedError()

--- a/src/mlops_codex/training/base.py
+++ b/src/mlops_codex/training/base.py
@@ -19,8 +19,9 @@ class ITrainingExecution(BaseModel, abc.ABC):
         frozen=True, title="Training hash", validate_default=True
     )
     group: str = Field(frozen=True, title="Training hash", validate_default=True)
+    model_type: str = Field(frozen=True, title="Training type", validate_default=True)
+
     execution_id: int = Field(default=None, gt=0)
-    model_type: str = Field(default=None)
     experiment_name: str = Field(default=None)
 
     login: str = Field(default=None, repr=False)
@@ -54,7 +55,6 @@ class ITrainingExecution(BaseModel, abc.ABC):
         )
 
         training_data = response.json()["Description"]
-        self.model_type = training_data["ModelType"]
         self.experiment_name = training_data["ExperimentName"]
 
     def _register_execution(self, run_name: str, description: str, training_type: str):

--- a/src/mlops_codex/training/base.py
+++ b/src/mlops_codex/training/base.py
@@ -165,7 +165,7 @@ class ITrainingExecution(BaseModel, abc.ABC):
 
     @property
     def status(self) -> str:
-        url = f"{self.mlops_class.base_url}/training/execution/{self.execution_id}"
+        url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}/status"
         token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
         response = make_request(
             url=url,

--- a/src/mlops_codex/training/training.py
+++ b/src/mlops_codex/training/training.py
@@ -21,6 +21,7 @@ from mlops_codex.exceptions import (
 )
 from mlops_codex.http_request_handler import refresh_token, make_request
 from mlops_codex.logger_config import get_logger
+from mlops_codex.shared import constants
 from mlops_codex.training.base import ITrainingExecution
 from mlops_codex.training.training_types import CustomTrainingExecution, AutoMLTrainingExecution
 from mlops_codex.validations import validate_group_existence, file_extension_validation
@@ -734,26 +735,13 @@ class MLOpsTrainingClient(BaseMLOpsClient):
         Invalid credentials
     ServerError
         Server unavailable
-
-    Example
-    -------
-    .. code-block:: python
-
-        from mlops_codex.training import MLOpsTrainingClient
-
-        client = MLOpsTrainingClient('123456')
-        client.create_group('ex_group', 'Group for example purpose')
-        training = client.create_training_experiment('Training example', 'Classification',  'Custom', 'ex_group')
-        print(client.get_training(training.training_id, 'ex_group').training_data)
-
     """
 
-    # TODO: improve it!
     def __repr__(self) -> str:
-        return f'Codex version 2.2.8'
+        return f'Codex version {constants.CODEX_VERSION}'
 
     def __str__(self):
-        return f'Codex version 2.2.8'
+        return f'Codex version {constants.CODEX_VERSION}'
 
     def get_training(self, *, training_hash: str, group: str) -> MLOpsTrainingExperiment:
         """

--- a/src/mlops_codex/training/training.py
+++ b/src/mlops_codex/training/training.py
@@ -672,6 +672,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
                     "upload_data": upload_data,
                     "conf_dict": conf_dict,
                     "extra_files": extra_files,
+                    "wait_complete": wait_complete,
                 },
             ),
         }

--- a/src/mlops_codex/training/training.py
+++ b/src/mlops_codex/training/training.py
@@ -611,6 +611,9 @@ class MLOpsTrainingExperiment(BaseMLOps):
                 "You must provide a data to train your model. It can be a path to a file or a dataset hash."
             )
 
+        if description is None:
+            description = f"Training is {training_type}"
+
         if extra_files is None:
             extra_files = []
 

--- a/src/mlops_codex/training/training.py
+++ b/src/mlops_codex/training/training.py
@@ -483,6 +483,21 @@ class MLOpsTrainingExperiment(BaseMLOps):
         return f'MLOPS training experiment "{self.experiment_name} (Group: {self.group}, Id: {self.training_hash})"'
 
     def __describe(self):
+        """
+        Describe the training experiment.
+
+        Returns
+        -------
+        dict
+            Description of the training experiment.
+
+        Raises
+        ------
+        TrainingError
+            When the training can't be accessed in the server
+        AuthenticationError 
+            Invalid credentials
+        """
         url = f"{self.base_url}/training/describe/{self.group}/{self.training_hash}"
         token = refresh_token(*self.credentials, self.base_url)
         response = make_request(
@@ -500,6 +515,19 @@ class MLOpsTrainingExperiment(BaseMLOps):
         return response.json()
 
     def succeeded_executions(self, mode="dict"):
+        """
+        Get the succeeded executions.
+
+        Parameters
+        ----------
+        mode: str, optional
+            The mode of the return value. Can be "dict" or "count". Default is "dict".
+
+        Returns
+        -------
+        Union[dict, int]
+            The succeeded executions in the specified mode.
+        """
         describe = self.__describe().get("SucceededExecutions")
         if mode == "dict":
             return describe
@@ -509,6 +537,19 @@ class MLOpsTrainingExperiment(BaseMLOps):
             raise InputError(f"Invalid mode {mode}")
 
     def executions(self, mode="dict"):
+        """
+        Get the executions.
+
+        Parameters
+        ----------
+        mode: str, optional
+            The mode of the return value. Can be "dict" or "count". Default is "dict".
+
+        Returns
+        -------
+        Union[dict, int]
+            The executions in the specified mode.
+        """
         describe = self.__describe().get("Executions")
         if mode == "dict":
             return describe

--- a/src/mlops_codex/training/training.py
+++ b/src/mlops_codex/training/training.py
@@ -636,6 +636,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
                 CustomTrainingExecution,
                 {
                     "training_hash": self.training_hash,
+                    "model_type": training_type,
                     "group": self.group,
                     "login": self.credentials[0],
                     "password": self.credentials[1],
@@ -657,6 +658,7 @@ class MLOpsTrainingExperiment(BaseMLOps):
                 AutoMLTrainingExecution,
                 {
                     "training_hash": self.training_hash,
+                    "model_type": training_type,
                     "group": self.group,
                     "login": self.credentials[0],
                     "password": self.credentials[1],

--- a/src/mlops_codex/training/training.py
+++ b/src/mlops_codex/training/training.py
@@ -1,0 +1,949 @@
+#!/usr/bin/env python
+# coding: utf-8
+import json
+import os
+import re
+import sys
+from contextlib import contextmanager
+from typing import Any, List, Optional, Union
+
+import cloudpickle
+import numpy as np
+import pandas as pd
+from lazy_imports import try_import
+
+from mlops_codex.base import BaseMLOps, BaseMLOpsClient, MLOpsExecution
+from mlops_codex.datasources import MLOpsDataset
+from mlops_codex.dataset import validate_dataset
+from mlops_codex.exceptions import (
+    InputError,
+    TrainingError,
+)
+from mlops_codex.http_request_handler import refresh_token, make_request
+from mlops_codex.logger_config import get_logger
+from mlops_codex.training.base import ITrainingExecution
+from mlops_codex.training.training_types import CustomTrainingExecution, AutoMLTrainingExecution
+from mlops_codex.validations import validate_group_existence, file_extension_validation
+
+patt = re.compile(r"(\d+)")
+logger = get_logger()
+
+
+class MLOpsTrainingLogger:
+    """A class for logging MLOps training runs.
+
+    Example
+    -------
+
+    .. code-block:: python
+        with training.log_train('Teste 1', X, y) as logger:
+            pipe.fit(X, y)
+            logger.save_model(pipe)
+
+            params = pipe.get_params()
+            params.pop('steps')
+            params.pop('simpleimputer')
+            params.pop('lgbmclassifier')
+            logger.save_params(params)
+
+            model_output = pd.DataFrame({"pred": pipe.predict(X), "proba": pipe.predict_proba(X)[:,1]})
+            logger.save_model_output(model_output)
+
+            auc = cross_val_score(pipe, X, y, cv=5, scoring="roc_auc")
+            f_score = cross_val_score(pipe, X, y, cv=5, scoring="f1")
+            logger.save_metric(name='auc', value=auc.mean())
+            logger.save_metric(name='f1_score', value=f_score.mean())
+
+            logger.set_python_version('3.10')
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        X_train: pd.DataFrame,
+        y_train: pd.DataFrame,
+        description: Optional[str] = None,
+        save_path: Optional[str] = None,
+    ):
+        """
+        Initialize a new MLOpsTrainingLogger.
+
+        Args:
+            name: The name of the training run.
+            X_train: The training data.
+            y_train: The training labels.
+        """
+        self.name = name
+        self.X_train = X_train
+        self.y_train = y_train
+        self.description = description
+        self.model_outputs = None
+        self.model = None
+        self.metrics = {}
+        self.params = {}
+        self.requirements = None
+        self.python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        self.extras = []
+
+        if not save_path:
+            dir_name = self.name.replace(" ", "_")
+            if not os.path.exists(f"./{dir_name}"):
+                os.mkdir(f"./{dir_name}")
+            self.save_path = f"./{dir_name}"
+
+    def save_model(self, model):
+        """
+        Save the trained model to the logger.
+
+        Parameters
+        ----------
+        model: object
+            The trained model.
+        """
+
+        self.model = model
+
+    def save_metric(self, *, name, value):
+        """
+        Save a metric to the logger.
+
+        Parameters
+        ----------
+        name: str
+            The name of the metric.
+        value: float
+            The value of the metric.
+        """
+
+        self.metrics[name] = value
+
+    def save_model_output(self, model_output):
+        """
+        Save the model output to the logger.
+
+        Parameters
+        ----------
+        model_output: object
+            The output of the trained model.
+        """
+
+        self.model_outputs = model_output
+
+    def set_python_version(self, version: str):
+        """
+        Set the Python version used to train the model.
+
+        Parameters
+        ----------
+        version: str
+            The Python version.
+        """
+
+        self.python_version = version
+
+    def set_requirements(self, requirements: str):
+        """
+        Set the project requirements.
+
+        Parameters
+        ----------
+        requirements: str
+            The path of project requirements.
+        """
+
+        self.requirements = requirements
+
+    def save_plot(self, *, plot: object, save_filename: str):
+        """
+        Save plot graphic image to the logger.
+
+        Parameters
+        ----------
+        plot: object
+            A Matplotlib/Plotly/Seaborn graphic object.
+        save_filename: str
+            A name to save the plot.
+        """
+
+        filepath = f"./{save_filename}.png"
+
+        with try_import() as _:
+            import plotly
+
+            if isinstance(plot, plotly.graph_objs.Figure):
+                self.save_plotly_plot(plot=plot, filepath=filepath)
+                return
+
+        with try_import() as _:
+            import seaborn as sns
+
+            if isinstance(plot, sns.axisgrid.FacetGrid):
+                self.save_seaborn_or_matplotlib_plot(plot=plot, filepath=filepath)
+                return
+
+        with try_import() as _:
+            import matplotlib.pyplot as plt
+
+            if isinstance(plot, plt.Figure):
+                self.save_seaborn_or_matplotlib_plot(plot=plot, filepath=filepath)
+                return
+
+        raise ValueError("The plot only accepts plots of Matplotlib/Plotly/Seaborn")
+
+    def save_plotly_plot(self, *, plot, filepath):
+        image_data = plot.to_image()
+        with open(filepath, "wb") as f:
+            f.write(image_data)
+        self.add_extra(extra=filepath)
+
+    def save_seaborn_or_matplotlib_plot(self, *, plot, filepath):
+        plot.savefig(filepath)
+        self.add_extra(extra=filepath)
+
+    def set_extra(self, extra: list):
+        """
+        Set the extra files list.
+
+        Parameters
+        ----------
+        extra: list
+            A list of paths of the extra files.
+        """
+
+        self.extras = extra
+
+    def add_extra(self, *, extra: Union[pd.DataFrame, str], filename: str = None):
+        """
+        Add an extra file in the extra file list.
+
+        Parameters
+        ----------
+        extra: Union[pd.DataFrame, str]
+            A path of an extra file or a list to include in extra file list.
+        filename: Optional[str], optional
+            A filename if the extra is a DataFrame.
+        """
+
+        if isinstance(extra, str):
+            if os.path.exists(extra):
+                self.extras.append(extra)
+            else:
+                raise FileNotFoundError("Extra file path not found!")
+        elif isinstance(extra, pd.DataFrame):
+            if filename:
+                self.extras.append(
+                    self.__to_parquet(output_filename=filename, input_data=extra)
+                )
+            else:
+                raise InputError("Needs a filename to save the dataframe parquet.")
+
+    def add_requirements(self, filename: str):
+        """
+        Add requirements file.
+
+        Parameters
+        ----------
+        filename: str
+            The name of output filename to save.
+        """
+
+        self.requirements = filename
+
+    def __to_parquet(self, *, output_filename: str, input_data: pd.DataFrame):
+        """
+        Transform dataframe to parquet.
+
+        Args:
+            output_filename: The name of output filename to save.
+            input_data: A pandas dataframe to save.
+        """
+        path = os.path.join(self.save_path, f"{output_filename}.parquet")
+        input_data.to_parquet(path)
+        return path
+
+    def __to_json(self, output_filename: str, input_data: dict):
+        """
+        Transform dict to json.
+
+        Args:
+            output_filename: The name of output filename to save.
+            input_data: A dictionary to save.
+        """
+        path = os.path.join(self.save_path, f"{output_filename}.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(input_data, f)
+        return path
+
+    def __to_pickle(self, *, output_filename: str, input_data):
+        """
+        Transform content to pickle.
+
+        Args:
+            output_filename: The name of output filename to save.
+            input_data: The content to save.
+        """
+        path = os.path.join(self.save_path, f"{output_filename}.pkl")
+        with open(path, "wb") as f:
+            cloudpickle.dump(input_data, f)
+        return path
+
+    def _set_params(self):
+        missing = self.X_train.isna().sum()
+        missing_dict = {
+            k + "_missings": v
+            for k, v in missing[missing > 0].describe().to_dict().items()
+            if k != "count"
+        }
+
+        params = {
+            "shape": self.X_train.shape,
+            "cols_with_missing": len(missing[missing > 0]),
+            "missing_distribution": missing_dict,
+        }
+
+        try:
+            params["pipeline_steps"] = list(self.model.named_steps.keys())
+        except Exception:
+            params["pipeline_steps"] = [
+                str(self.model.__class__).replace("<class '", "").replace("'>", "")
+            ]
+
+        if "get_all_params" in dir(self.model):
+            hyperparameters = {
+                f"hyperparam_{k}": str(v)
+                for k, v in self.model.get_all_params().items()
+                if k != "task_type"
+            }
+        elif "get_params" in dir(self.model):
+            hyperparameters = {
+                "hyperparam_" + k: str(v)
+                for k, v in self.model.get_params().items()
+                if k not in params["pipeline_steps"] + ["steps", "memory", "verbose"]
+            }
+
+            params = {**params, **hyperparameters}
+
+        if len(self.y_train.value_counts()) < 10:
+            target_proportion = self.y_train.value_counts() / len(self.y_train)
+            target_proportion = target_proportion.to_dict()
+            target_proportion = [
+                {"target": k, "proportion": v} for k, v in target_proportion.items()
+            ]
+            params["target_proportion"] = target_proportion
+        else:
+            params["target_distribution"] = {
+                k: v
+                for k, v in self.y_train.describe().to_dict().items()
+                if k != "count"
+            }
+
+        self.params = {**params, **self.params}
+
+    @staticmethod
+    def _parse_data_objects(obj: Any) -> pd.DataFrame:
+        """
+        Tranform data types to dataframe
+        """
+
+        if isinstance(obj, pd.Series):
+            return obj.to_frame()
+        elif isinstance(obj, np.ndarray):
+            array_df = pd.DataFrame(obj)
+            array_df.columns = [str(c) for c in array_df.columns]
+            return array_df
+        elif isinstance(obj, pd.DataFrame):
+            return obj
+
+    def _processing_logging_inputs(self):
+        """
+        Processing of everything that be logged.
+        """
+
+        self._set_params()
+        self.params = self.__to_json("params", self.params)
+
+        self.X_train = self.__to_parquet(
+            output_filename="features",
+            input_data=self._parse_data_objects(self.X_train),
+        )
+
+        self.y_train = self.__to_parquet(
+            output_filename="target", input_data=self._parse_data_objects(self.y_train)
+        )
+
+        self.model_outputs = self.__to_parquet(
+            output_filename="predictions",
+            input_data=self._parse_data_objects(self.model_outputs),
+        )
+
+        if self.model:
+            self.model = self.__to_pickle(
+                output_filename="model", input_data=self.model
+            )
+
+        if self.metrics:
+            self.metrics = self.__to_json("metrics", self.metrics)
+
+
+class MLOpsTrainingExperiment(BaseMLOps):
+    """
+    Class to manage models being trained inside MLOps
+
+    Parameters
+    ----------
+    login: str
+        Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
+    password: str
+        Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
+    training_hash: str
+        Training id (hash) from the experiment you want to access
+    group: str
+        Group the training is inserted.
+    environment: str
+        Flag that choose which environment of MLOps you are using. Test your deployment first before changing to production. Default is True
+    executions: List[int]
+        Ids for the executions in that training
+
+
+    Raises
+    ------
+    TrainingError
+        When the training can't be accessed in the server
+    AuthenticationError
+        Invalid credentials
+
+    Example
+    -------
+
+    .. code-block:: python
+
+        from mlops_codex.training import MLOpsTrainingClient
+        from mlops_codex.base import MLOpsExecution
+
+        client = MLOpsTrainingClient('123456')
+        client.create_group('ex_group', 'Group for example purpose')
+        training = client.create_training_experiment('Training example', 'Classification', 'ex_group')
+        print(client.get_training(training.training_id, 'ex_group').training_data)
+
+        data_path = './samples/train/'
+
+        run = run = training.run_training('First test', data_path+'dados.csv', training_reference='train_model', training_type='Custom', python_version='3.9', requirements_file=data_path+'requirements.txt', wait_complete=True)
+
+        print(run.get_training_execution(run.exec_id))
+        print(run.download_result())
+    """
+
+    def __init__(
+        self,
+        *,
+        training_hash: str,
+        group: str,
+        login: Optional[str] = None,
+        password: Optional[str] = None,
+        url: Optional[str] = "https://neomaril.datarisk.net/",
+    ) -> None:
+        super().__init__(login=login, password=password, url=url)
+
+        self.training_hash = training_hash
+        self.group = group
+
+        url = f"{self.base_url}/training/describe/{self.group}/{self.training_hash}"
+        token = refresh_token(*self.credentials, self.base_url)
+
+        response = make_request(
+            url=url,
+            method="GET",
+            success_code=200,
+            custom_exception=TrainingError,
+            custom_exception_message=f'Experiment "{training_hash}" not found.',
+            specific_error_code=404,
+            logger_msg=f'Experiment "{training_hash}" not found.',
+            headers={
+                f'Authorization': f'Bearer {token}',
+            }
+        )
+
+        training_data = response.json()["Description"]
+        self.model_type = training_data["ModelType"]
+        self.experiment_name = training_data["ExperimentName"]
+
+    def __repr__(self) -> str:
+        return f"""MLOpsTrainingExperiment(name="{self.experiment_name}", 
+                                                        group="{self.group}", 
+                                                        training_id="{self.training_hash}",
+                                                        model_type={str(self.model_type)}
+                                                        )"""
+
+    def __str__(self):
+        return f'MLOPS training experiment "{self.experiment_name} (Group: {self.group}, Id: {self.training_hash})"'
+
+    def __describe(self):
+        url = f"{self.base_url}/training/describe/{self.group}/{self.training_hash}"
+        token = refresh_token(*self.credentials, self.base_url)
+        response = make_request(
+            url=url,
+            method="GET",
+            success_code=200,
+            custom_exception=TrainingError,
+            headers={
+                f'Authorization': f'Bearer {token}',
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.__describe.__qualname__,
+            }
+        )
+
+        return response.json()
+
+    def succeeded_executions(self, mode="dict"):
+        describe = self.__describe().get("SucceededExecutions")
+        if mode == "dict":
+            return describe
+        elif mode == "count":
+            return len(describe)
+        else:
+            raise InputError(f"Invalid mode {mode}")
+
+    def executions(self, mode="dict"):
+        describe = self.__describe().get("Executions")
+        if mode == "dict":
+            return describe
+        elif mode == "count":
+            return len(describe)
+        else:
+            raise InputError(f"Invalid mode {mode}")
+
+    def run_training(
+        self,
+        *,
+        run_name: str,
+        training_type: str,
+        description: Optional[str] = None,
+        requirements_file: Optional[str] = None,
+        source_file: Optional[str] = None,
+        python_version: Optional[str] = "3.10",
+        training_reference: Optional[str] = None,
+        train_data: Optional[str] = None,
+        dataset: Union[str, MLOpsDataset] = None,
+        dataset_name: Optional[str] = "input",
+        conf_dict: Union[dict, str] = None,
+        features_file: Optional[str] = None,
+        target_file: Optional[str] = None,
+        predictions_file: Optional[str] = None,
+        metrics_file: Optional[str] = None,
+        parameters_file: Optional[str] = None,
+        model_file: Optional[str] = None,
+        extra_files: Optional[list] = None,
+        env: Optional[str] = None,
+        wait_complete: Optional[bool] = False,
+    ) -> ITrainingExecution:
+        """
+        Runs a prediction from the current model.
+
+        Parameters
+        ---------
+        run_name: str
+            The execution name in case you'd like to search it later. Obrigatory for all training types
+        training_type: str
+            Either 'Custom', 'External' or 'AutoML'
+        description: Optional[str], default=None
+            A small description to help you remember the training
+        source_file: Optional[str], default=None
+            Path to the python source file. Obrigatory for 'Custom' training
+        python_version: Optional[str], default='3.10'
+            Version of the python executable to run. Obrigatory for 'Custom' training, optional for 'External' training
+            The available options are: '3.8, '3.9' and '3.10'
+        training_reference: Optional[str], default=None
+            Entrypoint function name in the source file. Obrigatory for 'Custom' training
+        requirements_file: Optional[str], default=None
+            The requirements.txt file. Obrigatory for 'Custom' training if you wish to install dependencies
+        train_data: Optional[str], default=None
+            Data used to train the model. Obrigatory for 'Custom' and 'AutoML' training types
+        dataset_name: Optional[str], default="input"
+            Provided name the input file. Obrigatory for 'Custom' and 'AutoML' training types
+        dataset: Union[str, MLOpsDataset], default=None
+            Dataset generated or uploaded from other MLOps modules. It is a string, it must be the dataset hash. You can
+            also provide the entire dataset class
+        conf_dict: Optional[dict, str], default=None
+            Configuration file or dict. It's obrigatory for 'AutoML' training. You'll provide necessary configuration
+            for dealing with your data and how to train the model
+        features_file: Optional[str], default=None
+            Path to the features file. Obrigatory for 'External' training
+        target_file: Optional[str], default=None
+            Path to the target file. Obrigatory for 'External' training
+        predictions_file: Optional[str], default=None
+            Path to the predictions file. Obrigatory for 'External' training
+        metrics_file: Optional[str], default=None
+            Path to the metrics file. Obrigatory for 'External' training
+        parameters_file: Optional[str], default=None
+            Path to the parameters file. Obrigatory for 'External' training
+        model_file: Optional[str], default=None
+            Path to the model file. Obrigatory for 'External' training
+        extra_files: Optional[list], default=None
+            An optional list with path of files used to train your model
+        env: Optional[str], default=None
+            An optional path to the provide environment variables
+        wait_complete: Optional[bool], default=False
+            Lock your script/cell until training is complete.
+        Raises
+        ------
+        AuthenticationError
+        InputError
+
+        Returns
+        -------
+        Example
+        -------
+        >>> execution = run = training.run_training(run_name=,training_type=,requirements_file=data_path+'requirements.txt',python_version='3.9',training_reference='train_model',wait_complete=True)
+        """
+
+        if training_type not in ("Custom", "External", "AutoML"):
+            raise InputError("Training type needs be: 'Custom', 'AutoML' or 'External'.")
+
+        if dataset is None and train_data is None:
+            raise InputError(
+                "You must provide a data to train your model. It can be a path to a file or a dataset hash."
+            )
+
+        if extra_files is None:
+            extra_files = []
+
+        input_data = {}
+        upload_data = {}
+
+        if train_data:
+            file_extension_validation(train_data, {"csv", "parquet", "txt"})
+            upload_data["input"] = open(train_data, "rb")
+
+
+        if dataset is not None:
+            dataset_hash = validate_dataset(dataset)
+        else:
+            dataset_hash = None
+
+        input_train_data = dataset_hash if dataset_hash is not None else dataset_name
+        form = "dataset_hash" if dataset_hash is not None else "dataset_name"
+
+        input_data[form] = input_train_data
+
+        builder = {
+            "Custom": (
+                CustomTrainingExecution,
+                {
+                    "training_hash": self.training_hash,
+                    "group": self.group,
+                    "login": self.credentials[0],
+                    "password": self.credentials[1],
+                    "url": self.base_url,
+                    "run_name": run_name,
+                    "description": description,
+                    "input_data": input_data,
+                    "upload_data": upload_data,
+                    "requirements_file": requirements_file,
+                    "source_file": source_file,
+                    "python_version": python_version,
+                    "training_reference": training_reference,
+                    "extra_files": extra_files,
+                    "env": env,
+                    "wait_complete": wait_complete,
+                }
+            ),
+            "AutoML": (
+                AutoMLTrainingExecution,
+                {
+                    "training_hash": self.training_hash,
+                    "group": self.group,
+                    "login": self.credentials[0],
+                    "password": self.credentials[1],
+                    "url": self.base_url,
+                    "run_name": run_name,
+                    "description": description,
+                    "input_data": input_data,
+                    "upload_data": upload_data,
+                    "conf_dict": conf_dict,
+                    "extra_files": extra_files
+                }
+            )
+        }
+
+        builder_train_class, params = builder[training_type]
+        train = builder_train_class(**params)
+        return train
+
+    def get_training_execution(self, exec_id: Optional[str] = None):
+        """
+        Get the execution instance.
+
+        Parameters
+        ---------
+        exec_id: Optional[str], optional
+            Execution id. If not informed we get the last execution.
+
+        Returns
+        -------
+        MLOpsExecution
+            The chosen execution
+        """
+        raise NotImplementedError()
+
+
+    @contextmanager
+    def log_train(
+        self,
+        *,
+        name,
+        X_train,
+        y_train,
+        description: Optional[str] = None,
+        save_path: Optional[str] = None,
+    ):
+        try:
+            self.trainer = MLOpsTrainingLogger(
+                name=name,
+                X_train=X_train,
+                y_train=y_train,
+                description=description,
+                save_path=save_path,
+            )
+            yield self.trainer
+
+        finally:
+            self.trainer._processing_logging_inputs()
+            self.run_training(run_name=self.trainer.name, training_type="External",
+                              description=self.trainer.description, requirements_file=self.trainer.requirements,
+                              python_version=self.trainer.python_version, model_file=self.trainer.model,
+                              extra_files=self.trainer.extras)
+
+
+class MLOpsTrainingClient(BaseMLOpsClient):
+    """
+    Class for client for accessing MLOps and manage models
+
+    Parameters
+    ----------
+    login: str
+        Login for authenticating with the client. You can also use the env variable MLOPS_USER to set this
+    password: str
+        Password for authenticating with the client. You can also use the env variable MLOPS_PASSWORD to set this
+    url: str
+        URL to MLOps Server. Default value is https://neomaril.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable MLOPS_URL to set this
+
+    Raises
+    ------
+    AuthenticationError
+        Invalid credentials
+    ServerError
+        Server unavailable
+
+    Example
+    -------
+    .. code-block:: python
+
+        from mlops_codex.training import MLOpsTrainingClient
+
+        client = MLOpsTrainingClient('123456')
+        client.create_group('ex_group', 'Group for example purpose')
+        training = client.create_training_experiment('Training example', 'Classification',  'Custom', 'ex_group')
+        print(client.get_training(training.training_id, 'ex_group').training_data)
+
+    """
+
+    # TODO: improve it!
+    def __repr__(self) -> str:
+        return f'Codex version 2.2.8'
+
+    def __str__(self):
+        return f'Codex version 2.2.8'
+
+    def get_training(self, *, training_hash: str, group: str) -> MLOpsTrainingExperiment:
+        """
+        Acess a model using its id
+
+        Parameters
+        ---------
+        training_hash: str
+            Training id (hash) that needs to be acessed
+        group: str
+            Group the model is inserted.
+
+        Raises
+        ------
+        TrainingError
+            Model unavailable
+        ServerError
+            Unknown return from server
+
+        Returns
+        -------
+        MLOpsTrainingExperiment
+            A MLOpsTrainingExperiment instance with the training hash from `training_id`
+
+        Example
+        -------
+        >>> training = get_training('Tfb3274827a24dc39d5b78603f348aee8d3dbfe791574dc4a6681a7e2a6622fa')
+        """
+
+        return MLOpsTrainingExperiment(training_hash=training_hash, login=self.credentials[0],
+                                       password=self.credentials[1], group=group, url=self.base_url)
+
+    def __get_repeated_thash(
+        self, model_type: str, experiment_name: str, group: str
+    ) -> Union[str, None]:
+        """Look for a previous train experiment.
+
+        Args:
+            experiment_name (str): name given to the training, should be not null, case-sensitive, have between 3 and 32 characters,
+                                   that could be alphanumeric including accentuation (for example: 'é', à', 'ç','ñ') and space,
+                                   without blank spaces and special characters
+
+            model_type (str): type of the model being trained. It can be
+                                Classification: for ML algorithms related to classification (predicts discrete class labels) problems;
+                                Regression: the ones that will use regression (predict a continuous quantity) algorithms;
+                                Unsupervised: for training that will use ML algorithms without supervision.
+
+            group (str): name of the group, previous created, where the training will be inserted
+
+        Raises:
+            InputError: some part of the data is incorrect
+            AuthenticationError: user has insufficient permissions
+            ServerError: server is not available
+            Exception: generated exception in case of the response to the request is different from 201
+
+        Returns:
+            str | None: THash if it is found, otherwise, None is returned
+        """
+        url = f"{self.base_url}/training/search"
+        token = refresh_token(*self.credentials, self.base_url)
+
+        response = make_request(
+            url=url,
+            method="GET",
+            success_code=200,
+            headers={
+                "Authorization": f"Bearer {token}",
+            }
+        )
+
+        results = response.json().get("Results")
+        for result in results:
+            condition = (
+                result["ExperimentName"] == experiment_name
+                and result["GroupName"] == group
+                and result["ModelType"] == model_type
+            )
+            if condition:
+                logger.info("Found experiment with same attributes...")
+                return result["TrainingHash"]
+
+    def __register_training(self, experiment_name: str, model_type: str, group: str) -> str:
+        """Creates a train experiment. A train experiment can aggregate multiple training runs (also called executions).
+        Each execution can eventually become a deployed model or not.
+
+        Args:
+            experiment_name (str): name given to the training, should be not null, case-sensitive, have between 3 and 32 characters,
+                                   that could be alphanumeric including accentuation (for example: 'é', à', 'ç','ñ') and space,
+                                   without blank spaces and special characters
+
+            model_type (str): type of the model being trained. It can be
+                                Classification: for ML algorithms related to classification (predicts discrete class labels) problems;
+                                Regression: the ones that will use regression (predict a continuous quantity) algorithms;
+                                Unsupervised: for training that will use ML algorithms without supervision.
+
+            group (str): name of the group, previous created, where the training will be inserted
+
+        Raises:
+            InputError: some part of the data is incorrect
+            AuthenticationError: user has insufficient permissions
+            ServerError: server is not available
+            Exception: generated exception in case of the response to the request is different from 201
+
+        Returns:
+            str: training hash of the experiment
+        """
+        url = f"{self.base_url}/v2/training/{group}"
+        token = refresh_token(*self.credentials, self.base_url)
+
+        payload = {"Name": experiment_name, "Type": model_type}
+
+        response = make_request(
+            url=url,
+            method="POST",
+            success_code=201,
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.__register_training.__qualname__,
+            }
+        )
+
+        response_data = response.json()
+        logger.info(response_data["Message"])
+        training_hash = response_data["TrainingHash"]
+        return training_hash
+
+    def create_training_experiment(
+        self,
+        *,
+        experiment_name: str,
+        model_type: str,
+        group: str,
+        force: Optional[bool] = False,
+    ) -> MLOpsTrainingExperiment:
+        """
+        Create a new training experiment on MLOps.
+
+        Parameters
+        ---------
+        experiment_name: str
+            The name of the experiment, in less than 32 characters
+        model_type: str
+            The name of the scoring function inside the source file.
+        group: str
+            Group the model is inserted. Default to 'datarisk' (public group)
+        force: Optional[bool], optional
+            Forces to create a new training with the same model_type, experiment_name, group
+
+        Raises
+        ------
+        InputError
+            Some input parameters its invalid
+        ServerError
+            Unknow internal server error
+
+        Returns
+        -------
+        MLOpsTrainingExperiment
+            A MLOpsTrainingExperiment instance with the training hash from `training_id`
+
+        Example
+        -------
+        >>> training = client.create_training_experiment('Training example', 'Classification', 'ex_group')
+        """
+
+        validate_group_existence(group, self)
+
+        if model_type not in ["Classification", "Regression", "Unsupervised"]:
+            raise InputError(
+                f"Invalid model_type {model_type}. Should be one of the following: Classification, Regression or "
+                f"Unsupervised"
+            )
+
+        logger.info("Trying to load experiment...")
+        training_hash = self.__get_repeated_thash(
+            model_type=model_type, experiment_name=experiment_name, group=group
+        )
+
+        if force or training_hash is None:
+            msg = (
+                "The experiment you're creating has identical name, group, and model type attributes to an existing one. "
+                + "Since forced creation is active, we will continue with the process as specified"
+                if force
+                else "Could not find experiment. Creating a new one..."
+            )
+            logger.info(msg)
+            training_hash = self.__register_training(experiment_name=experiment_name, model_type=model_type,
+                                                     group=group)
+
+        return MLOpsTrainingExperiment(training_hash=training_hash, login=self.credentials[0],
+                                       password=self.credentials[1], group=group, url=self.base_url)

--- a/src/mlops_codex/training/training_types.py
+++ b/src/mlops_codex/training/training_types.py
@@ -34,8 +34,6 @@ class CustomTrainingExecution(ITrainingExecution):
                 f"The parameters {fields_required} it's mandatory on custom training."
             )
 
-        python_version = validate_python_version(values["python_version"])
-
         source_file = values["source_file"]
         file_extension_validation(source_file, {"py", "ipynb"})
 
@@ -52,7 +50,6 @@ class CustomTrainingExecution(ITrainingExecution):
         )
 
         data = {key: values[key] for key in keys}
-        data["python_version"] = python_version
 
         return data
 
@@ -129,7 +126,7 @@ class CustomTrainingExecution(ITrainingExecution):
         token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
         upload_data = {"script": open(script_path, "rb")}
         input_data = {
-            "train_reference": train_reference,
+            "training_reference": train_reference,
             "python_version": python_version,
         }
         response = make_request(
@@ -163,10 +160,12 @@ class CustomTrainingExecution(ITrainingExecution):
 
         self._upload_requirements(requirements_file=data["requirements_file"])
 
+        python_version = validate_python_version(data["python_version"])
+
         self.__upload_script_file(
             script_path=data["source_file"],
             train_reference=data["training_reference"],
-            python_version=data["python_version"],
+            python_version=python_version,
         )
 
         for path, name in data["extras"]:

--- a/src/mlops_codex/training/training_types.py
+++ b/src/mlops_codex/training/training_types.py
@@ -184,14 +184,14 @@ class AutoMLTrainingExecution(ITrainingExecution):
     @classmethod
     def validate(cls, values):
         fields_required = (
-            "train_data",
+            "input_data",
+            "upload_data",
             "conf_dict",
             "run_name",
-            "description",
         )
 
         if (not all(k in values for k in fields_required)) or (
-            not all(v for v in values.values())
+            not all(values[f] for f in fields_required)
         ):
             raise InputError(
                 f"The parameters {fields_required} it's mandatory on automl training."
@@ -213,7 +213,7 @@ class AutoMLTrainingExecution(ITrainingExecution):
         return data
 
     def __upload_conf_dict(self, conf_dict):
-        url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}/confi-dict/file"
+        url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}/conf-dict/file"
         token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
 
         upload_data = {"conf_dict": parse_dict_or_file(conf_dict)}

--- a/src/mlops_codex/training/training_types.py
+++ b/src/mlops_codex/training/training_types.py
@@ -1,0 +1,190 @@
+from pydantic import model_validator
+
+from mlops_codex.__model_states import ModelTypes
+from mlops_codex.__utils import parse_dict_or_file
+from mlops_codex.exceptions import InputError
+from mlops_codex.http_request_handler import refresh_token, make_request
+from mlops_codex.logger_config import get_logger
+from mlops_codex.training.base import ITrainingExecution
+from mlops_codex.validations import validate_python_version, file_extension_validation
+
+logger = get_logger()
+
+
+class CustomTrainingExecution(ITrainingExecution):
+
+    @model_validator(mode="before")
+    def validate(self, values):
+        fields_required = (
+            "input_data", "upload_data", "run_name", "train_data", "source_file",
+            "requirements_file", "train_reference", "python_version",
+        )
+
+        if (not all(k in values for k in fields_required)) or (not all(v for v in values.values())):
+            raise InputError(f"The parameters {fields_required} it's mandatory on custom training.")
+
+        python_version = values["python_version"]
+        python_version = validate_python_version(python_version)
+
+        source_file = values["source_file"]
+        file_extension_validation(source_file, {"py", "ipynb"})
+
+        requirements_file = values["requirements_file"]
+        file_extension_validation(requirements_file, {"txt"})
+
+        self.execution_id = self._register_execution(
+            run_name=values["run_name"],
+            description=values["description"],
+            training_type="Custom"
+        )
+
+        self._upload_input_file(input_data=values["input_data"], upload_data=values["upload_data"])
+
+        self._upload_requirements(requirements_file=requirements_file)
+
+        self.__upload_script_file(script_path=source_file, train_reference=values["train_reference"],
+                                  python_version=python_version)
+
+        for path, name in values["extras"]:
+            self._upload_extra_files(extra_files_path=path, name=name)
+
+        if values["env"]:
+            self._upload_env_file(env_file=values["env"])
+
+        self.host()
+
+        if values["wait_complete"]:
+            self.wait_ready()
+
+    # This function is not accessible to users. When the promote endpoint is changed, I'll make some updates here
+    def __promote(
+        self,
+        model_name: str,
+        operation: str,
+        source_file: str,
+        model_reference: str,
+        schema: str,
+        requirements_file: str = None,
+        input_type: str = None,
+        env: str = None,
+        extra_files: list = None,
+        wait_complete: bool = False
+    ):
+        schema_extension = schema.split(".")[-1]
+        self._promote_validation(operation=operation, input_type=input_type, schema_extension=schema_extension)
+        operation = ModelTypes[operation.title()]
+
+        file_extension_validation(source_file, {"py", "ipynb"})
+
+        file_extension_validation(schema, {"json", "xml", "csv", "parquet"})
+        file_extension_validation(requirements_file, {"txt"})
+        file_extension_validation(env, {"env"})
+
+        input_data = {
+            "name": model_name, "operation": operation, "schema": schema,
+            "model_reference": model_reference, "input_type": input_type,
+        }
+
+        upload_data = [
+            ("source", ("app.py", open(source_file, "rb"))),
+            ("schema", (f"schema.{schema_extension}", parse_dict_or_file(schema)))
+        ]
+        if env is not None:
+            upload_data.append(("env", (".env", open(env, "rb"))))
+
+        if requirements_file is not None:
+            upload_data.append(("requirements", ("requirements.txt", open(requirements_file, "rb"))))
+
+        if extra_files is not None:
+            extra_data = [
+                ("extra", (c.split("/")[-1], open(c, "rb"))) for c in extra_files
+            ]
+
+            upload_data += extra_data
+
+        self._promote(
+            upload_data=upload_data,
+            input_data=input_data,
+            operation=operation,
+            model_name=model_name,
+            wait_complete=wait_complete,
+        )
+
+    def promote(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def __upload_script_file(self, script_path: str, train_reference: str, python_version: str):
+        url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}/script-file"
+        token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
+        upload_data = {"script": open(script_path, "rb")}
+        input_data = {"train_reference": train_reference, "python_version": python_version}
+        response = make_request(
+            url=url,
+            method="PATCH",
+            success_code=201,
+            data=input_data,
+            files=upload_data,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.__upload_script_file.__qualname__,
+            }
+        )
+
+        msg = response.json()["Message"]
+        logger.info(msg)
+
+
+class AutoMLTrainingExecution(ITrainingExecution):
+
+    @model_validator(mode="before")
+    def validate(self, values):
+        fields_required = (
+            "train_data", "conf_dict", "run_name", "description",
+        )
+
+        if (not all(k in values for k in fields_required)) or (not all(v for v in values.values())):
+            raise InputError(f"The parameters {fields_required} it's mandatory on automl training.")
+
+        file_extension_validation(values["conf_dict"], {"json"})
+
+        self.execution_id = self._register_execution(
+            run_name=values["run_name"],
+            description=values["description"],
+            training_type="AutoML"
+        )
+
+        self.__upload_conf_dict(conf_dict=values["conf_dict"])
+
+        self._upload_input_file(input_data=values["input_data"], upload_data=values["upload_data"])
+
+        for path, name in values["extras"]:
+            self._upload_extra_files(extra_files_path=path, name=name)
+
+        self.host()
+
+        if values["wait_complete"]:
+            self.wait_ready()
+
+    def __upload_conf_dict(self, conf_dict):
+        url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}/confi-dict/file"
+        token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
+
+        upload_data = {"conf_dict": parse_dict_or_file(conf_dict)}
+        response = make_request(
+            url=url,
+            method="PATCH",
+            success_code=201,
+            files=upload_data,
+            headers={
+                f'Authorization': f'Bearer {token}',
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.__upload_conf_dict.__qualname__,
+            }
+        ).json()
+
+        msg = response["Message"]
+        logger.info(msg)
+
+    def promote(self, *args, **kwargs):
+        raise NotImplementedError()

--- a/src/mlops_codex/training/training_types.py
+++ b/src/mlops_codex/training/training_types.py
@@ -163,10 +163,9 @@ class CustomTrainingExecution(ITrainingExecution):
 
         self._upload_requirements(requirements_file=data["requirements_file"])
 
-
         self.__upload_script_file(
             script_path=data["source_file"],
-            train_reference=data["train_reference"],
+            train_reference=data["training_reference"],
             python_version=data["python_version"],
         )
 

--- a/src/mlops_codex/training/training_types.py
+++ b/src/mlops_codex/training/training_types.py
@@ -145,7 +145,6 @@ class CustomTrainingExecution(ITrainingExecution):
         msg = response.json()["Message"]
         logger.info(msg)
 
-
     def __init__(self, **data):
         super().__init__(**data)
         self.execution_id = self._register_execution(
@@ -168,7 +167,7 @@ class CustomTrainingExecution(ITrainingExecution):
             python_version=python_version,
         )
 
-        for path, name in data["extras"]:
+        for name, path in data["extra_files"]:
             self._upload_extra_files(extra_files_path=path, name=name)
 
         if data["env"]:
@@ -211,7 +210,7 @@ class AutoMLTrainingExecution(ITrainingExecution):
             input_data=values["input_data"], upload_data=values["upload_data"]
         )
 
-        for path, name in values["extras"]:
+        for path, name in values["extra_files"]:
             self._upload_extra_files(extra_files_path=path, name=name)
 
         self.host()

--- a/src/mlops_codex/training/training_types.py
+++ b/src/mlops_codex/training/training_types.py
@@ -12,9 +12,48 @@ logger = get_logger()
 
 
 class CustomTrainingExecution(ITrainingExecution):
+    """
+    Custom training execution class.
+
+    Parameters
+    ----------
+    training_hash: str
+        Training hash.
+    group: str
+        Group where the training is inserted.
+    model_type: str
+        Type of the model.
+    execution_id: int
+        Execution ID of a training.
+    experiment_name: str
+        Name of the experiment.
+    login: str
+        Login credential.
+    password: str
+        Password credential.
+    url: str
+        URL used to connect to the MLOps server.
+    mlops_class: BaseMLOps
+        MLOps class instance.
+    """
+
     @model_validator(mode="before")
     @classmethod
     def validate(cls, values):
+        """
+        Validates the input values for custom training execution.
+
+        Parameters
+        ----------
+        values: dict
+            Dictionary of input values.
+
+        Returns
+        -------
+        dict
+            Validated input values.
+        """
+
         logger.info("Validating data...")
 
         fields_required = (
@@ -67,6 +106,37 @@ class CustomTrainingExecution(ITrainingExecution):
         extra_files: list = None,
         wait_complete: bool = False,
     ):
+        """
+        Promotes the current execution.
+
+        Parameters
+        ----------
+        model_name: str
+            Name of the model.
+        operation: str
+            Operation type.
+        source_file: str
+            Path to the source file.
+        model_reference: str
+            Model reference.
+        schema: str
+            Schema file.
+        requirements_file: str, optional
+            Path to the requirements file.
+        input_type: str, optional
+            Input type.
+        env: str, optional
+            Path to the environment file.
+        extra_files: list, optional
+            List of extra files.
+        wait_complete: bool, optional
+            Whether to wait for completion.
+
+        Returns
+        -------
+        None
+        """
+
         schema_extension = schema.split(".")[-1]
         self._promote_validation(
             operation=operation,
@@ -117,11 +187,43 @@ class CustomTrainingExecution(ITrainingExecution):
         )
 
     def promote(self, *args, **kwargs):
+        """
+        Abstract method to promote the execution.
+
+        Parameters
+        ----------
+        args: tuple
+            Positional arguments.
+        kwargs: dict
+            Keyword arguments.
+
+        Returns
+        -------
+        None
+        """
+
         raise NotImplementedError()
 
     def __upload_script_file(
         self, script_path: str, train_reference: str, python_version: str
     ):
+        """
+        Uploads the script file.
+
+        Parameters
+        ----------
+        script_path: str
+            Path to the script file.
+        train_reference: str
+            Training reference.
+        python_version: str
+            Python version.
+
+        Returns
+        -------
+        None
+        """
+
         url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}/script-file"
         token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
         upload_data = {"script": open(script_path, "rb")}
@@ -180,9 +282,48 @@ class CustomTrainingExecution(ITrainingExecution):
 
 
 class AutoMLTrainingExecution(ITrainingExecution):
+    """
+    AutoML training execution class.
+
+    Parameters
+    ----------
+    training_hash: str
+        Training hash.
+    group: str
+        Group where the training is inserted.
+    model_type: str
+        Type of the model.
+    execution_id: int
+        Execution ID of a training.
+    experiment_name: str
+        Name of the experiment.
+    login: str
+        Login credential.
+    password: str
+        Password credential.
+    url: str
+        URL used to connect to the MLOps server.
+    mlops_class: BaseMLOps
+        MLOps class instance.
+    """
+
     @model_validator(mode="before")
     @classmethod
     def validate(cls, values):
+        """
+        Validates the input values for AutoML training execution.
+
+        Parameters
+        ----------
+        values: dict
+            Dictionary of input values.
+
+        Returns
+        -------
+        dict
+            Validated input values.
+        """
+
         fields_required = (
             "input_data",
             "upload_data",
@@ -213,6 +354,19 @@ class AutoMLTrainingExecution(ITrainingExecution):
         return data
 
     def __upload_conf_dict(self, conf_dict):
+        """
+        Uploads the configuration dictionary.
+
+        Parameters
+        ----------
+        conf_dict: str
+            Path to the configuration dictionary.
+
+        Returns
+        -------
+        None
+        """
+
         url = f"{self.mlops_class.base_url}/v2/training/execution/{self.execution_id}/conf-dict/file"
         token = refresh_token(*self.mlops_class.credentials, self.mlops_class.base_url)
 
@@ -233,6 +387,21 @@ class AutoMLTrainingExecution(ITrainingExecution):
         logger.info(msg)
 
     def promote(self, *args, **kwargs):
+        """
+        Abstract method to promote the execution.
+
+        Parameters
+        ----------
+        args: tuple
+            Positional arguments.
+        kwargs: dict
+            Keyword arguments.
+
+        Returns
+        -------
+        None
+        """
+        
         raise NotImplementedError()
 
     def __init__(self, **data):

--- a/src/mlops_codex/training/validations.py
+++ b/src/mlops_codex/training/validations.py
@@ -1,0 +1,1 @@
+# Specific validators for training

--- a/src/mlops_codex/validations.py
+++ b/src/mlops_codex/validations.py
@@ -26,7 +26,7 @@ def validate_group_existence(group: str, client_object: BaseMLOpsClient) -> bool
     raise GroupError("Group dont exist. Create a group first.")
 
 
-def validate_python_version(python_version: str) -> bool:
+def validate_python_version(python_version: str) -> str:
     """
     Validates that the Python version is valid.
 
@@ -40,7 +40,7 @@ def validate_python_version(python_version: str) -> bool:
         raise InputError(
             "Invalid python version. Available versions are 3.8, 3.9, 3.10"
         )
-    return True
+    return "Python" + python_version.replace(".", "")
 
 
 def date_validation(start: str, end: str) -> Tuple[str, str]:


### PR DESCRIPTION
## Description

With this pr:
- Refactor training module by creating a new module for training;
- Introduces specialized classes to deal with different training types;
- Add `constants.py` to deal with shared constants in the project;
- Improve logic in python_version validator;
- Add function to check if a file is dataset or a path to a file;
- Improve logs;

## Related issues

Closes:
- https://linear.app/datarisk/issue/NEODV-1617/refatorar-outros-endpoints-de-treino-no-codex
- https://linear.app/datarisk/issue/NEODV-1615/refatorar-treino-automl-no-codex
- https://linear.app/datarisk/issue/NEODV-1614/reatorar-treino-custom-no-codex

## How to test it

- Setup your environment (see the uv example):

```shell
uv pip uninstall datarisk-mlops-codex && pipenv update --dev && pipenv shell
pipenv sync
```

- Run the `notebooks/TrainingV2.ipynb`
- Assert it is working
 
 **PR Summary by Typo**
------------

**Overview**
This PR refactors training endpoints in the Codex library, introduces a new versioning constant, and improves dataset validation.  A new `TrainingV2.ipynb` notebook demonstrates the updated training workflow.

**Key Changes**
- Refactored training endpoints to use v2 API.
- Introduced `MLOpsTrainingLogger` for enhanced logging during training.
- Added dataset validation to ensure correct dataset usage.
- Updated `lightgbm` dependency version.
- Added `CODEX_VERSION` constant for version tracking.
- Created new modules for better code organization (`__init__.py` files added in `shared` and `training`).
- Several functions were updated across multiple files to accommodate these changes, including `run_training`, `upload_file`, `register_monitoring`, `__upload_model`, and `create_model`.

**Recommendations**
Not deployment ready. While the changes seem beneficial, more thorough testing and documentation are needed before merging into production.  Add unit tests to cover the refactored training endpoints and the new dataset validation logic. Update the documentation to reflect the API changes and provide usage examples for the new features.  Clarify the purpose and usage of the `ModelTypes` enum, which seems underutilized.  Consider adding a changelog entry for the version bump.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>