### PR TITLE
Techdebt adicionar um aviso de versao depreciada no codex neodv 1704

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-from mlops_codex.shared.constants import CODEX_VERSION
+from src.mlops_codex.shared.constants import CODEX_VERSION
 
 MODULE_NAME = 'datarisk_mlops_codex'
 MODULE_NAME_IMPORT = 'mlops_codex'

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 from setuptools import setup, find_packages
 
+from mlops_codex.shared.constants import CODEX_VERSION
+
 MODULE_NAME = 'datarisk_mlops_codex'
 MODULE_NAME_IMPORT = 'mlops_codex'
 REPO_NAME = 'mlops_codex'
-MODULE_VERSION='2.2.8'
 
 
 def requirements_from_pip(filename='requirements.txt'):
@@ -19,8 +20,8 @@ setup(name=MODULE_NAME,
       long_description_content_type='text/markdown',
       package_dir={'': 'src'},
       packages=find_packages('src'),
-      version=MODULE_VERSION,
-      download_url=f'https://github.com/datarisk-io/mlops_codex/archive/refs/tags/v{MODULE_VERSION}.tar.gz',
+      version=CODEX_VERSION,
+      download_url=f'https://github.com/datarisk-io/mlops_codex/archive/refs/tags/v{CODEX_VERSION}.tar.gz',
       install_requires=requirements_from_pip(),
       include_package_data=True,
       zip_safe=False,

--- a/src/mlops_codex/base.py
+++ b/src/mlops_codex/base.py
@@ -21,6 +21,7 @@ from mlops_codex.exceptions import (
 )
 from mlops_codex.http_request_handler import refresh_token, try_login
 from mlops_codex.logger_config import get_logger
+from mlops_codex.shared.utils import check_lib_version
 
 logger = get_logger()
 
@@ -42,6 +43,8 @@ class BaseMLOps:
         if not loaded:
             load_dotenv(find_dotenv(usecwd=True))
         logger.info("Loading .env")
+
+        check_lib_version()
 
         if url is None:
             url = os.getenv("MLOPS_URL")

--- a/src/mlops_codex/shared/utils.py
+++ b/src/mlops_codex/shared/utils.py
@@ -1,6 +1,9 @@
 from typing import BinaryIO, Dict, Optional, Tuple
 
+import requests
+
 from mlops_codex.exceptions import InputError
+from mlops_codex.shared.constants import CODEX_VERSION
 
 
 def parse_data(
@@ -58,3 +61,19 @@ def parse_data(
         return {form_data: dataset_hash}, None
 
     raise InputError("You must provide either a file path or a dataset hash.")
+
+
+def check_lib_version():
+    response = requests.get(
+        "https://pypi.org/pypi/datarisk-mlops-codex/json"
+    )
+
+    if response.status_code != 200:
+        return
+
+    json_data = response.json()
+
+    info = json_data["info"]
+    major_version = info["version"]
+    if major_version != CODEX_VERSION:
+        print(f"You are using {CODEX_VERSION}, but version {major_version} is recommended.")

--- a/src/mlops_codex/shared/utils.py
+++ b/src/mlops_codex/shared/utils.py
@@ -67,8 +67,7 @@ def parse_data(
 @ttl_cache
 def check_lib_version():
     response = requests.get(
-        "https://pypi.org/pypi/datarisk-mlops-codex/json",
-        timeout=60
+        "https://pypi.org/pypi/datarisk-mlops-codex/json", timeout=60
     )
 
     if response.status_code != 200:
@@ -79,4 +78,6 @@ def check_lib_version():
     info = json_data["info"]
     major_version = info["version"]
     if major_version != CODEX_VERSION:
-        print(f"You are using {CODEX_VERSION}, but version {major_version} is recommended.")
+        print(
+            f"You are using {CODEX_VERSION}, but version {major_version} is recommended."
+        )

--- a/src/mlops_codex/shared/utils.py
+++ b/src/mlops_codex/shared/utils.py
@@ -65,7 +65,8 @@ def parse_data(
 
 def check_lib_version():
     response = requests.get(
-        "https://pypi.org/pypi/datarisk-mlops-codex/json"
+        "https://pypi.org/pypi/datarisk-mlops-codex/json",
+        timeout=60
     )
 
     if response.status_code != 200:

--- a/src/mlops_codex/shared/utils.py
+++ b/src/mlops_codex/shared/utils.py
@@ -1,6 +1,7 @@
 from typing import BinaryIO, Dict, Optional, Tuple
 
 import requests
+from cachetools.func import ttl_cache
 
 from mlops_codex.exceptions import InputError
 from mlops_codex.shared.constants import CODEX_VERSION
@@ -63,6 +64,7 @@ def parse_data(
     raise InputError("You must provide either a file path or a dataset hash.")
 
 
+@ttl_cache
 def check_lib_version():
     response = requests.get(
         "https://pypi.org/pypi/datarisk-mlops-codex/json",

--- a/src/mlops_codex/training/trigger.py
+++ b/src/mlops_codex/training/trigger.py
@@ -292,7 +292,7 @@ def trigger_external_training(**kwargs) -> int:
         send_json(
             url=f"{kwargs['url']}/v2/training/execution/{execution_id}/python-version",
             token=kwargs["token"],
-            input_data={
+            payload={
                 "PythonVersion": validate_python_version(
                     python_version=kwargs["python_version"]
                 )


### PR DESCRIPTION
## Description

With this pr:
- Sends a message if the user is using an outdated version

## Related issues

- Closed: https://linear.app/datarisk/issue/NEODV-1704/[techdebt]-adicionar-um-aviso-de-versao-depreciada-no-codex
 
 
 
 
 
 **PR Summary by Typo**
------------

**Overview:**
This PR implements a version check against PyPI to notify users of available updates for the `datarisk-mlops-codex` library.  It introduces a new utility function and integrates it into the library's initialization process.

**Key Changes:**
- Added `CODEX_VERSION` constant.
- Implemented `check_lib_version` function to fetch the latest version from PyPI and compare it with the current version.
- Integrated the version check into the `Codex` class initialization.
- Modified `trigger_external_training` to use `payload` instead of `input_data`.
- Updated `setup.py` to use the `CODEX_VERSION` constant.

**Recommendations:**
Not deployment ready.  While the version check is a good addition, the implementation could be improved by: 1. Logging the version mismatch instead of printing to the console.  This allows for better tracking and integration with logging systems. 2. Providing a configuration option to disable the version check for users who may not want this functionality.  This adds flexibility and control.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>